### PR TITLE
Host parameters treated like snippets

### DIFF
--- a/src/language/sql/document.ts
+++ b/src/language/sql/document.ts
@@ -198,6 +198,7 @@ export default class Document {
     }
 
     return {
+      changed: areas.length > 0,
       content: newContent,
       parameterCount
     };

--- a/src/language/sql/statement.ts
+++ b/src/language/sql/statement.ts
@@ -477,6 +477,7 @@ export default class Statement {
 				case `statementType`:
 					if (declareStmt) continue;
 
+					// If we're in a DECLARE, it's likely a cursor definition
 					if (currentToken.value.toLowerCase() === `declare`) {
 						declareStmt = currentToken;
 					}
@@ -485,6 +486,7 @@ export default class Statement {
 				case `clause`:
 					if (declareStmt) continue;
 
+					// We need to remove the INTO clause completely.
 					if (currentToken.value.toLowerCase() === `into`) {
 						intoClause = currentToken;
 					} else if (intoClause) {
@@ -520,6 +522,10 @@ export default class Statement {
 					let followingTokenI = i+1;
 					let endToken: Token;
 
+					// Handles when we have a host variable
+					// This logic supports qualified host variables
+					// i.e. :myvar or :mystruct.subf
+
 					let followingToken = this.tokens[followingTokenI];
 					while (followingToken && followingToken.type === nextMustBe) {
 						switch (followingToken.type) {
@@ -549,6 +555,7 @@ export default class Statement {
 
 				default:
 					if (i === 0 && tokenIs(currentToken, `word`, `EXEC`)) {
+						// We check and remove the starting `EXEC SQL`
 						if (tokenIs(this.tokens[i+1], `word`, `SQL`)) {
 							ranges.push({
 								type: `remove`,
@@ -560,6 +567,8 @@ export default class Statement {
 						}
 					} else 
 					if (declareStmt && tokenIs(currentToken, `keyword`, `FOR`)) {
+						// If we're a DECLARE, and we found the FOR keyword, the next
+						// set of tokens should be the select.
 						ranges.push({
 							type: `remove`,
 							range: {

--- a/src/language/sql/tests/statements.test.ts
+++ b/src/language/sql/tests/statements.test.ts
@@ -1267,4 +1267,51 @@ describe(`Parameter statement tests`, () => {
     const result = document.removeEmbeddedAreas(statement);
     expect(result.content).toBe(`select x,y from sample where x = ?`);
   });
+
+  test(`Exec with basic DECLARE`, () => {
+    const lines = [
+      `EXEC SQL DECLARE empCur CURSOR FOR`,
+      `  SELECT EMPNO, FIRSTNME, LASTNAME, JOB`,
+      `  FROM EMPLOYEE`,
+      `  WHERE WORKDEPT = :DEPTNO`,
+    ].join(`\n`);
+
+    const document = new Document(lines);
+    const statements = document.statements;
+    expect(statements.length).toBe(1);
+
+    const statement = statements[0];
+
+    const result = document.removeEmbeddedAreas(statement);
+    expect(result.parameterCount).toBe(1);
+    expect(result.content).toBe([
+      `  SELECT EMPNO, FIRSTNME, LASTNAME, JOB`,
+      `  FROM EMPLOYEE`,
+      `  WHERE WORKDEPT = ?`
+    ].join(`\n`));
+  });
+
+  test(`Exec with basic DECLARE`, () => {
+    const lines = [
+      `EXEC SQL`,
+      `DECLARE cursor-name SCROLL CURSOR FOR`,
+      `SELECT column-1, column-2`,
+      `  FROM table-name`,
+      `  WHERE column-1 = expression`,
+    ].join(`\n`);
+
+    const document = new Document(lines);
+    const statements = document.statements;
+    expect(statements.length).toBe(1);
+
+    const statement = statements[0];
+
+    const result = document.removeEmbeddedAreas(statement);
+    expect(result.parameterCount).toBe(0);
+    expect(result.content).toBe([
+      `SELECT column-1, column-2`,
+      `  FROM table-name`,
+      `  WHERE column-1 = expression`,
+    ].join(`\n`));
+  });
 });

--- a/src/language/sql/types.ts
+++ b/src/language/sql/types.ts
@@ -98,3 +98,8 @@ export interface Definition extends ObjectRef {
 	range: IRange;
 	children: Definition[];
 }
+
+export interface ParsedEmbeddedStatement {
+	content: string;
+	parameterCount: number;
+}

--- a/src/language/sql/types.ts
+++ b/src/language/sql/types.ts
@@ -100,6 +100,7 @@ export interface Definition extends ObjectRef {
 }
 
 export interface ParsedEmbeddedStatement {
+	changed: boolean;
 	content: string;
 	parameterCount: number;
 }

--- a/src/views/results/index.ts
+++ b/src/views/results/index.ts
@@ -1,4 +1,4 @@
-import vscode, { SnippetString } from "vscode"
+import vscode, { SnippetString, ViewColumn } from "vscode"
 
 import * as csv from "csv/sync";
 
@@ -129,6 +129,8 @@ export interface StatementInfo {
   content: string,
   qualifier: StatementQualifier,
   open?: boolean,
+  viewColumn?: ViewColumn,
+  viewFocus?: boolean,
   history?: boolean
 }
 
@@ -160,7 +162,7 @@ export function initialise(context: vscode.ExtensionContext) {
 
           if (statementDetail.open) {
             const textDoc = await vscode.workspace.openTextDocument({ language: `sql`, content: statementDetail.content });
-            editor = await vscode.window.showTextDocument(textDoc);
+            editor = await vscode.window.showTextDocument(textDoc, statementDetail.viewColumn, statementDetail.viewFocus);
           }
 
           if (editor) {

--- a/src/views/results/index.ts
+++ b/src/views/results/index.ts
@@ -244,7 +244,7 @@ export function initialise(context: vscode.ExtensionContext) {
                 }
               }
 
-              if (statementDetail.qualifier === `statement`) {
+              if (statementDetail.qualifier === `statement` && statementDetail.history) {
                 vscode.commands.executeCommand(`vscode-db2i.queryHistory.prepend`, statementDetail.content);
               }
 

--- a/src/views/results/index.ts
+++ b/src/views/results/index.ts
@@ -167,7 +167,7 @@ export function initialise(context: vscode.ExtensionContext) {
             const group = statementDetail.group;
             editor.selection = new vscode.Selection(editor.document.positionAt(group.range.start), editor.document.positionAt(group.range.end));
 
-            if (statementDetail.embeddedInfo.parameterCount > 0) {
+            if (group.statements.length === 1 && statementDetail.embeddedInfo.parameterCount > 0) {
               editor.insertSnippet(
                 new SnippetString(statementDetail.embeddedInfo.content)
               )

--- a/src/views/results/index.ts
+++ b/src/views/results/index.ts
@@ -169,7 +169,7 @@ export function initialise(context: vscode.ExtensionContext) {
             const group = statementDetail.group;
             editor.selection = new vscode.Selection(editor.document.positionAt(group.range.start), editor.document.positionAt(group.range.end));
 
-            if (group.statements.length === 1 && statementDetail.embeddedInfo.parameterCount > 0) {
+            if (group.statements.length === 1 && statementDetail.embeddedInfo.changed) {
               editor.insertSnippet(
                 new SnippetString(statementDetail.embeddedInfo.content)
               )

--- a/src/views/results/index.ts
+++ b/src/views/results/index.ts
@@ -246,7 +246,7 @@ export function initialise(context: vscode.ExtensionContext) {
                 }
               }
 
-              if (statementDetail.qualifier === `statement` && statementDetail.history) {
+              if (statementDetail.qualifier === `statement` && statementDetail.history !== false) {
                 vscode.commands.executeCommand(`vscode-db2i.queryHistory.prepend`, statementDetail.content);
               }
 

--- a/src/views/results/index.ts
+++ b/src/views/results/index.ts
@@ -156,7 +156,7 @@ export function initialise(context: vscode.ExtensionContext) {
         if (optionsIsValid || (editor && editor.document.languageId === `sql`)) {
           await resultSetProvider.ensureActivation();
 
-          const statementDetail = parseStatement(editor, options);
+          const statementDetail = parseStatement(editor, optionsIsValid ? options : undefined);
 
           if (statementDetail.open) {
             const textDoc = await vscode.workspace.openTextDocument({ language: `sql`, content: statementDetail.content });


### PR DESCRIPTION
When a statement is ran, but has host parameters, user will be expected to fix them up before the statement can be executed.

The statement will not execute and the user will be able to tab through the parameters to set the values.