### PR TITLE
Feature/self codes

### DIFF
--- a/package.json
+++ b/package.json
@@ -318,6 +318,11 @@
         "category": "Db2 for i"
       },
       {
+        "command": "vscode-db2i.jobManager.getSelfErrors",
+        "title": "Get SELFCODES Errors",
+        "category": "Db2 for i"
+      },
+      {
         "command": "vscode-db2i.jobManager.newConfig",
         "title": "Save settings to config",
         "category": "Db2 for i",
@@ -368,6 +373,10 @@
         },
         {
           "command": "vscode-db2i.jobManager.enableTracing",
+          "when": "never"
+        },
+        {
+          "command": "vscode-db2i.jobManager.getSelfErrors",
           "when": "never"
         },
         {
@@ -553,6 +562,11 @@
           "command": "vscode-db2i.jobManager.getTrace",
           "when": "view == jobManager && viewItem == sqlJob",
           "group": "trace@2"
+        },
+        {
+          "command": "vscode-db2i.jobManager.getSelfErrors",
+          "when": "view == jobManager && viewItem == sqlJob",
+          "group": "trace@3"
         },
         {
           "command": "vscode-db2i.jobManager.newConfig",

--- a/package.json
+++ b/package.json
@@ -290,6 +290,12 @@
         "icon": "$(edit)"
       },
       {
+        "command": "vscode-db2i.jobManager.editSelfCodes",
+        "title": "Edit SELFCODES",
+        "category": "Db2 for i",
+        "icon": "$(bracket-error)"
+      },
+      {
         "command": "vscode-db2i.jobManager.copyJobId",
         "title": "Copy Job Name",
         "category": "Db2 for i",
@@ -346,6 +352,10 @@
         },
         {
           "command": "vscode-db2i.jobManager.editJobProps",
+          "when": "never"
+        },
+        {
+          "command": "vscode-db2i.jobManager.editSelfCodes",
           "when": "never"
         },
         {
@@ -516,6 +526,11 @@
         },
         {
           "command": "vscode-db2i.jobManager.editJobProps",
+          "when": "view == jobManager && viewItem == sqlJob",
+          "group": "inline"
+        },
+        {
+          "command": "vscode-db2i.jobManager.editSelfCodes",
           "when": "view == jobManager && viewItem == sqlJob",
           "group": "inline"
         },

--- a/package.json
+++ b/package.json
@@ -291,7 +291,7 @@
       },
       {
         "command": "vscode-db2i.jobManager.editSelfCodes",
-        "title": "Edit SELFCODES",
+        "title": "Edit SELF codes",
         "category": "Db2 for i",
         "icon": "$(bracket-error)"
       },
@@ -319,7 +319,7 @@
       },
       {
         "command": "vscode-db2i.jobManager.getSelfErrors",
-        "title": "Get SELFCODES Errors",
+        "title": "Get SELF codes Errors",
         "category": "Db2 for i"
       },
       {

--- a/package.json
+++ b/package.json
@@ -541,7 +541,7 @@
         {
           "command": "vscode-db2i.jobManager.editSelfCodes",
           "when": "view == jobManager && viewItem == sqlJob",
-          "group": "inline"
+          "group": "self@2"
         },
         {
           "command": "vscode-db2i.jobManager.copyJobId",
@@ -566,7 +566,7 @@
         {
           "command": "vscode-db2i.jobManager.getSelfErrors",
           "when": "view == jobManager && viewItem == sqlJob",
-          "group": "trace@3"
+          "group": "self@1"
         },
         {
           "command": "vscode-db2i.jobManager.newConfig",

--- a/src/connection/sqlJob.ts
+++ b/src/connection/sqlJob.ts
@@ -231,8 +231,9 @@ export class SQLJob {
   }
 
   async setSelfCodes(codes: string[]) {
+    const signedCodes: String[] = codes.map(code => [code, `-${code}`]).flat();
     try {
-      const query: string = `SET SYSIBMADM.SELFCODES = SYSIBMADM.VALIDATE_SELF('${codes.join(', ')}')`
+      const query: string = `SET SYSIBMADM.SELFCODES = SYSIBMADM.VALIDATE_SELF('${signedCodes.join(', ')}')`
       await this.query<any>(query).run();
       this.options.selfcodes = codes;
     } catch (e) {

--- a/src/connection/sqlJob.ts
+++ b/src/connection/sqlJob.ts
@@ -230,6 +230,16 @@ export class SQLJob {
     return rpy;
   }
 
+  async setSelfCodes(codes: string[]) {
+    try {
+      const query: string = `SET SYSIBMADM.SELFCODES = SYSIBMADM.VALIDATE_SELF('${codes.join(', ')}')`
+      await this.query<any>(query).run();
+      this.options.selfcodes = codes;
+    } catch (e) {
+      throw e;
+    }
+  }
+
   async setTraceConfig(dest: ServerTraceDest, level: ServerTraceLevel): Promise<SetConfigResult> {
     const reqObj = {
       id: SQLJob.getNewUniqueId(),

--- a/src/connection/types.ts
+++ b/src/connection/types.ts
@@ -77,6 +77,8 @@ export interface ColumnMetaData {
 export type Rows = {[column: string]: string|number|boolean}[];
 
 export interface JDBCOptions {
+  // selfcodes
+  selfcodes?: string[];
   // Format properties
   "naming"?: "sql" | "system";
   "date format"?:

--- a/src/testing/index.ts
+++ b/src/testing/index.ts
@@ -6,9 +6,11 @@ import { ManagerSuite } from "./manager";
 import { JobsSuite } from "./jobs";
 import { DatabaseSuite } from "./database";
 import { DatabasePerformanceSuite } from "./databasePerformance";
+import { SelfCodesTestSuite } from "./selfCodes";
 
 const suites : TestSuite[] = [
   JobsSuite,
+  SelfCodesTestSuite,
   ManagerSuite,
   DatabaseSuite,
   DatabasePerformanceSuite

--- a/src/testing/jobs.ts
+++ b/src/testing/jobs.ts
@@ -1,11 +1,10 @@
 import assert from "assert";
 import { TestSuite } from ".";
-import { JobStatus, SQLJob } from "../connection/sqlJob";
 import { getInstance } from "../base";
-import { ServerComponent } from "../connection/serverComponent";
-import { ServerTraceDest, ServerTraceLevel } from "../connection/types";
 import { Query } from "../connection/query";
-import { testSelfCodes } from "../views/jobManager/selfCodes/selfCodesTest";
+import { ServerComponent } from "../connection/serverComponent";
+import { JobStatus, SQLJob } from "../connection/sqlJob";
+import { ServerTraceDest, ServerTraceLevel } from "../connection/types";
 
 export const JobsSuite: TestSuite = {
   name: `Connection tests`,
@@ -419,6 +418,5 @@ export const JobsSuite: TestSuite = {
       console.log(`Old query method took ${oe - os} milliseconds.`);
       assert.equal((ne - ns) < (oe - os), true);
     }},
-    ...testSelfCodes()
   ]
 }

--- a/src/testing/jobs.ts
+++ b/src/testing/jobs.ts
@@ -5,6 +5,7 @@ import { getInstance } from "../base";
 import { ServerComponent } from "../connection/serverComponent";
 import { ServerTraceDest, ServerTraceLevel } from "../connection/types";
 import { Query } from "../connection/query";
+import { testSelfCodes } from "../views/jobManager/selfCodes/selfCodesTest";
 
 export const JobsSuite: TestSuite = {
   name: `Connection tests`,
@@ -418,5 +419,6 @@ export const JobsSuite: TestSuite = {
       console.log(`Old query method took ${oe - os} milliseconds.`);
       assert.equal((ne - ns) < (oe - os), true);
     }},
+    ...testSelfCodes()
   ]
 }

--- a/src/testing/manager.ts
+++ b/src/testing/manager.ts
@@ -91,24 +91,6 @@ export const ManagerSuite: TestSuite = {
       assert.strictEqual(JobManager.getSelection().name, runningJobs[0].name);
 
       await JobManager.endAll();
-    }},
-    {name: `Get SELF codes Errors`, test: async () => {
-      assert.strictEqual(ServerComponent.isInstalled(), true);
-
-      // Ensure we have a blank manager first
-      await JobManager.endAll();
-      assert.strictEqual(JobManager.getRunningJobs().length, 0);
-      assert.strictEqual(JobManager.selectedJob, -1);
-
-      // Add a new job
-      await JobManager.newJob();
-
-      // Check the job exists
-      assert.strictEqual(JobManager.getRunningJobs().length, 1);
-
-      const curJob = JobManager.getRunningJobs();
-
-    }},
-    ...testSelfCodes()
+    }}
   ]
 }

--- a/src/testing/manager.ts
+++ b/src/testing/manager.ts
@@ -3,6 +3,7 @@ import { TestSuite } from ".";
 import { JobManager } from "../config";
 import { ServerComponent } from "../connection/serverComponent";
 import { JobStatus, SQLJob } from "../connection/sqlJob";
+import { testSelfCodes } from "../views/jobManager/selfCodes/selfCodesTest";
 
 export const ManagerSuite: TestSuite = {
   name: `Job manager tests`,
@@ -107,29 +108,7 @@ export const ManagerSuite: TestSuite = {
 
       const curJob = JobManager.getRunningJobs();
 
-      // set self codes
-      curJob[0].job.setSelfCodes(['138', '180'])
-
-      // SQL0138, get left-most 1001 characters of C2. C2 is only 100 characters long, so SQL0138 is produced
-      const sqlTestChar = `SELECT LEFT(C2, 1001) FROM SELFTEST.MYTBL`
-
-      await JobManager.runSQL(sqlTestChar);
-
-      const content = `SELECT * FROM QSYS2.SQL_ERROR_LOG WHERE JOB_NAME = '${curJob[0].job.id}'`;
-
-      const data = await JobManager.runSQL(content);
-
-      assert.strictEqual(data.length, 1);
-
-      // SQL0180, invalid format for date given
-      const sqltestDate = `VALUES DATE('120-1231-12312')`;
-
-      await JobManager.runSQL(sqltestDate);
-
-      const newData = await JobManager.runSQL(content);
-
-      assert.strictEqual(newData.length, 2);
-
-    }}
+    }},
+    ...testSelfCodes()
   ]
 }

--- a/src/testing/manager.ts
+++ b/src/testing/manager.ts
@@ -92,7 +92,7 @@ export const ManagerSuite: TestSuite = {
 
       await JobManager.endAll();
     }},
-    {name: `Get SELFCODES Errors`, test: async () => {
+    {name: `Get SELF codes Errors`, test: async () => {
       assert.strictEqual(ServerComponent.isInstalled(), true);
 
       // Ensure we have a blank manager first

--- a/src/testing/manager.ts
+++ b/src/testing/manager.ts
@@ -2,8 +2,7 @@ import assert from "assert";
 import { TestSuite } from ".";
 import { JobManager } from "../config";
 import { ServerComponent } from "../connection/serverComponent";
-import { JobStatus, SQLJob } from "../connection/sqlJob";
-import { testSelfCodes } from "../views/jobManager/selfCodes/selfCodesTest";
+import { JobStatus } from "../connection/sqlJob";
 
 export const ManagerSuite: TestSuite = {
   name: `Job manager tests`,

--- a/src/testing/manager.ts
+++ b/src/testing/manager.ts
@@ -2,8 +2,7 @@ import assert from "assert";
 import { TestSuite } from ".";
 import { JobManager } from "../config";
 import { ServerComponent } from "../connection/serverComponent";
-import { JobStatus } from "../connection/sqlJob";
-import { setSelfCodes } from "../views/jobManager/selfCodes/selfCodesBrowser";
+import { JobStatus, SQLJob } from "../connection/sqlJob";
 
 export const ManagerSuite: TestSuite = {
   name: `Job manager tests`,
@@ -109,7 +108,7 @@ export const ManagerSuite: TestSuite = {
       const curJob = JobManager.getRunningJobs();
 
       // set self codes
-      setSelfCodes(['138', '180'])
+      curJob[0].job.setSelfCodes(['138', '180'])
 
       // SQL0138, get left-most 1001 characters of C2. C2 is only 100 characters long, so SQL0138 is produced
       const sqlTestChar = `SELECT LEFT(C2, 1001) FROM SELFTEST.MYTBL`

--- a/src/testing/manager.ts
+++ b/src/testing/manager.ts
@@ -3,6 +3,7 @@ import { TestSuite } from ".";
 import { JobManager } from "../config";
 import { ServerComponent } from "../connection/serverComponent";
 import { JobStatus } from "../connection/sqlJob";
+import { setSelfCodes } from "../views/jobManager/selfCodes/selfCodesBrowser";
 
 export const ManagerSuite: TestSuite = {
   name: `Job manager tests`,
@@ -91,5 +92,45 @@ export const ManagerSuite: TestSuite = {
 
       await JobManager.endAll();
     }},
+    {name: `Get SELFCODES Errors`, test: async () => {
+      assert.strictEqual(ServerComponent.isInstalled(), true);
+
+      // Ensure we have a blank manager first
+      await JobManager.endAll();
+      assert.strictEqual(JobManager.getRunningJobs().length, 0);
+      assert.strictEqual(JobManager.selectedJob, -1);
+
+      // Add a new job
+      await JobManager.newJob();
+
+      // Check the job exists
+      assert.strictEqual(JobManager.getRunningJobs().length, 1);
+
+      const curJob = JobManager.getRunningJobs();
+
+      // set self codes
+      setSelfCodes(['138', '180'])
+
+      // SQL0138, get left-most 1001 characters of C2. C2 is only 100 characters long, so SQL0138 is produced
+      const sqlTestChar = `SELECT LEFT(C2, 1001) FROM SELFTEST.MYTBL`
+
+      await JobManager.runSQL(sqlTestChar);
+
+      const content = `SELECT * FROM QSYS2.SQL_ERROR_LOG WHERE JOB_NAME = '${curJob[0].job.id}'`;
+
+      const data = await JobManager.runSQL(content);
+
+      assert.strictEqual(data.length, 1);
+
+      // SQL0180, invalid format for date given
+      const sqltestDate = `VALUES DATE('120-1231-12312')`;
+
+      await JobManager.runSQL(sqltestDate);
+
+      const newData = await JobManager.runSQL(content);
+
+      assert.strictEqual(newData.length, 2);
+
+    }}
   ]
 }

--- a/src/testing/selfCodes.ts
+++ b/src/testing/selfCodes.ts
@@ -1,0 +1,7 @@
+import { TestSuite } from ".";
+import { testSelfCodes } from "../views/jobManager/selfCodes/selfCodesTest";
+
+export const SelfCodesTestSuite: TestSuite = {
+  name: `Self Codes Tests`,
+  tests: [...testSelfCodes()]
+}

--- a/src/testing/selfCodes.ts
+++ b/src/testing/selfCodes.ts
@@ -1,7 +1,44 @@
+import assert from "assert";
 import { TestSuite } from ".";
+import { ServerComponent } from "../connection/serverComponent";
 import { testSelfCodes } from "../views/jobManager/selfCodes/selfCodesTest";
+import { getInstance } from "../base";
 
 export const SelfCodesTestSuite: TestSuite = {
   name: `Self Codes Tests`,
-  tests: [...testSelfCodes()]
+  tests: [
+    {name: `Backend check`, test: async () => {
+      const backendInstalled = await ServerComponent.initialise();
+  
+      // To run these tests, we need the backend server. If this test fails. Don't bother
+      assert.strictEqual(backendInstalled, true);
+      try {
+        const selfTestSchema = [
+          `CREATE SCHEMA SELFTEST;`,
+          ``,
+          `CREATE OR REPLACE TABLE SELFTEST.MYTBL (C1 INT, C2 VARCHAR(100), C3 TIMESTAMP, C4 DATE);`,
+          ``,
+          `CREATE OR REPLACE TABLE SELFTEST.MYTBL2 (C1 INT, C2 VARCHAR(100), C3 TIMESTAMP, C4 DATE);`,
+          ``,
+          `INSERT INTO SELFTEST.MYTBL VALUES (0, 'ADAM', CURRENT TIMESTAMP, CURRENT DATE);`,
+          ``,
+          `INSERT INTO SELFTEST.MYTBL VALUES (1, 'LIAM', CURRENT TIMESTAMP + 1 SECOND, CURRENT DATE + 1 DAY);`,
+          ``,
+          `INSERT INTO SELFTEST.MYTBL VALUES (2, 'RYAN', CURRENT TIMESTAMP + 2 SECOND, CURRENT DATE + 2 DAY);`,
+          ``,
+          `INSERT INTO SELFTEST.MYTBL VALUES (3, NULL, CURRENT TIMESTAMP + 2 SECOND, CURRENT DATE + 2 DAY);`,
+          ``,
+          `INSERT INTO SELFTEST.MYTBL2 VALUES (0, 'TIM', CURRENT TIMESTAMP, CURRENT DATE);`,
+          ``,
+          `INSERT INTO SELFTEST.MYTBL2 VALUES (1, 'SCOTT', CURRENT TIMESTAMP + 1 SECOND, CURRENT DATE + 1 DAY);`,
+          ``,
+          `INSERT INTO SELFTEST.MYTBL2 VALUES (2, 'JESSIE', CURRENT TIMESTAMP + 2 SECOND, CURRENT DATE + 2 DAY);`
+        ]
+        await getInstance().getContent().runSQL(selfTestSchema.join(`\n`));
+
+      } catch (e) {
+        console.log(`Possible fail`);
+      }
+    }},
+    ...testSelfCodes()]
 }

--- a/src/views/jobManager/jobManagerView.ts
+++ b/src/views/jobManager/jobManagerView.ts
@@ -150,7 +150,7 @@ export class JobManagerView implements TreeDataProvider<any> {
             quickPick.items = [
               {
                 kind: vscode.QuickPickItemKind.Separator,
-                label: "Currently selected schemas",
+                label: "Currently selected SELFCODES",
               },
               ...currentSelfCodeItems,
               {

--- a/src/views/jobManager/jobManagerView.ts
+++ b/src/views/jobManager/jobManagerView.ts
@@ -144,18 +144,18 @@ export class JobManagerView implements TreeDataProvider<any> {
               );
 
             const quickPick = vscode.window.createQuickPick();
-            quickPick.title = `Select SELFCODES`;
+            quickPick.title = `Select SELF codes`;
             quickPick.canSelectMany = true;
             quickPick.matchOnDetail = true;
             quickPick.items = [
               {
                 kind: vscode.QuickPickItemKind.Separator,
-                label: "Currently selected SELFCODES",
+                label: "Currently selected SELF codes",
               },
               ...currentSelfCodeItems,
               {
                 kind: vscode.QuickPickItemKind.Separator,
-                label: "All Available SELFCODES",
+                label: "All Available SELF codes",
               },
               ...selfCodeItems.filter((item) =>
                 currentSelfCodeItems

--- a/src/views/jobManager/jobManagerView.ts
+++ b/src/views/jobManager/jobManagerView.ts
@@ -9,6 +9,8 @@ import { ServerComponent } from "../../connection/serverComponent";
 import { updateStatusBar } from "./statusBar";
 import { SQLJob, TransactionEndType } from "../../connection/sqlJob";
 import { ConfigGroup, ConfigManager } from "./ConfigManager";
+import { selfCodesMap } from "./selfCodes/selfCodes";
+import { SelfCodesQuickPickItem } from "./selfCodes/selfCodesBrowser";
 
 const selectJobCommand = `vscode-db2i.jobManager.selectJob`;
 const activeColor = new vscode.ThemeColor(`minimapGutter.addedBackground`);
@@ -124,6 +126,35 @@ export class JobManagerView implements TreeDataProvider<any> {
               })
             }
           })
+        }
+      }),
+
+      vscode.commands.registerCommand(`vscode-db2i.jobManager.editSelfCodes`, async (node?: SQLJobItem) => {
+        const id = node ? node.label as string : undefined;
+        let selected = id ? JobManager.getJob(id) : JobManager.getSelection();
+        if (selected) {
+          try {
+            const selfCodeItems = selfCodesMap.map(code => new SelfCodesQuickPickItem(code));
+  
+            const quickPick = vscode.window.createQuickPick();
+            quickPick.title = `Select SELFCODES`;
+            quickPick.canSelectMany = true;
+            quickPick.matchOnDetail = true;
+            quickPick.items = [
+              {kind: vscode.QuickPickItemKind.Separator, label: "Ryan's Favorites"},
+              ...selfCodeItems,
+              {kind: vscode.QuickPickItemKind.Separator, label: "All Available SELFCODES"}
+            ];
+  
+            quickPick.onDidAccept(() => {
+              const selections = quickPick.selectedItems;
+              quickPick.hide()
+            })
+            quickPick.onDidHide(() => quickPick.dispose());
+            quickPick.show();
+          } catch (e) {
+            vscode.window.showErrorMessage(e.message);
+          }
         }
       }),
 

--- a/src/views/jobManager/jobManagerView.ts
+++ b/src/views/jobManager/jobManagerView.ts
@@ -1,16 +1,15 @@
-import vscode, { MarkdownString, ProgressLocation, ThemeIcon, TreeItem, TreeItemCollapsibleState, Uri, commands, env, window, workspace } from "vscode";
-import { TreeDataProvider } from "vscode";
-import { Config, JobManager } from "../../config";
-import { JobInfo, SQLJobManager } from "../../connection/manager";
+import vscode, { ProgressLocation, TreeDataProvider, TreeItemCollapsibleState, Uri, commands, env, window } from "vscode";
+import { JobManager } from "../../config";
+import { JobInfo } from "../../connection/manager";
+import { ServerComponent } from "../../connection/serverComponent";
+import { SQLJob, TransactionEndType } from "../../connection/sqlJob";
+import { ServerTraceDest, ServerTraceLevel } from "../../connection/types";
+import { ConfigGroup, ConfigManager } from "./ConfigManager";
 import { editJobUi } from "./editJob";
 import { displayJobLog } from "./jobLog";
-import { ServerTraceDest, ServerTraceLevel } from "../../connection/types";
-import { ServerComponent } from "../../connection/serverComponent";
-import { updateStatusBar } from "./statusBar";
-import { SQLJob, TransactionEndType } from "../../connection/sqlJob";
-import { ConfigGroup, ConfigManager } from "./ConfigManager";
 import { selfCodesMap } from "./selfCodes/selfCodes";
-import { SelfCodesQuickPickItem, setSelfCodes } from "./selfCodes/selfCodesBrowser";
+import { SelfCodesQuickPickItem } from "./selfCodes/selfCodesBrowser";
+import { updateStatusBar } from "./statusBar";
 
 const selectJobCommand = `vscode-db2i.jobManager.selectJob`;
 const activeColor = new vscode.ThemeColor(`minimapGutter.addedBackground`);
@@ -171,8 +170,8 @@ export class JobManagerView implements TreeDataProvider<any> {
               // SET SYSIBMADM.SELFCODES = SYSIBMADM.VALIDATE_SELF('-514, -204, -501, +30, -199');
               if (selections) {
                 const codes: string[] = selections.map((code) => code.label);
-                setSelfCodes(codes);
-                selected.job.options.selfcodes = codes;
+                selected.job.setSelfCodes(codes);
+                vscode.window.showInformationMessage(`Applied SELF codes: ${codes}`);
               }
               quickPick.hide();
             });

--- a/src/views/jobManager/jobManagerView.ts
+++ b/src/views/jobManager/jobManagerView.ts
@@ -184,6 +184,21 @@ export class JobManagerView implements TreeDataProvider<any> {
         }
       }),
 
+      vscode.commands.registerCommand(`vscode-db2i.jobManager.getSelfErrors`, async (node?: SQLJobItem) => {
+        if (node) {
+          const id = node.label as string;
+          const selected = await JobManager.getJob(id);
+
+          const content = `SELECT * FROM QSYS2.SQL_ERROR_LOG WHERE JOB_NAME = '${selected.job.id}'`;
+
+          vscode.commands.executeCommand(`vscode-db2i.runEditorStatement`, {
+            content,
+            qualifier: `statement`,
+            open: false,
+          });
+        }
+      }),
+
       vscode.commands.registerCommand(`vscode-db2i.jobManager.enableTracing`, async (node?: SQLJobItem) => {
         if (node) {
           const id = node.label as string;

--- a/src/views/jobManager/selfCodes/selfCodes.ts
+++ b/src/views/jobManager/selfCodes/selfCodes.ts
@@ -1,0 +1,25 @@
+export interface SelfCodeObject {
+  code: string;
+  message: string;
+}
+
+export const selfCodesMap: SelfCodeObject[] = [
+  { code: "138", message: "Argument of substringing function not valid" },
+  { code: "180", message: "Syntax of date, time, or timestamp not valid" },
+  {
+    code: "181",
+    message: "Value in date, time, or timestamp string not valid",
+  },
+  { code: "182", message: "A date, time, or timestamp expression not valid" },
+  { code: "183", message: "Result of date or timestamp expression not valid" },
+  { code: "199", message: "Keyword not expected, valid tokens:" },
+  { code: "203", message: "Name is ambiguous" },
+  { code: "204", message: "&1 in &2 type *&3 not found." },
+  { code: "205", message: "Column not in table" },
+  { code: "206", message: "Column or global variable not found" },
+  { code: "304", message: "Conversion error in assignment to variable" },
+  { code: "420", message: "Value for cast argument not valid" },
+  { code: "551", message: "Not authorized to object &1 in &2 type *&3." },
+  { code: "802", message: "Data conversion or mapping error" },
+  { code: "811", message: "Result of SELECT more than one row." },
+];

--- a/src/views/jobManager/selfCodes/selfCodesBrowser.ts
+++ b/src/views/jobManager/selfCodes/selfCodesBrowser.ts
@@ -17,7 +17,7 @@ export async function setSelfCodes(codes: string[]) {
   try {
     await JobManager.runSQL(`SET SYSIBMADM.SELFCODES = SYSIBMADM.VALIDATE_SELF('${codes.join(', ')}')`);
 
-    vscode.window.showInformationMessage(`Applied SELFCODES: ${codes}`);
+    vscode.window.showInformationMessage(`Applied SELF codes: ${codes}`);
   } catch (e) {
     vscode.window.showErrorMessage(e.message);
   }

--- a/src/views/jobManager/selfCodes/selfCodesBrowser.ts
+++ b/src/views/jobManager/selfCodes/selfCodesBrowser.ts
@@ -1,7 +1,6 @@
 import * as vscode from 'vscode';
-import { SelfCodeObject } from './selfCodes';
-import { JDBCOptions } from '../../../connection/types';
 import { JobManager } from '../../../config';
+import { SelfCodeObject } from './selfCodes';
 
 export class SelfCodesQuickPickItem implements vscode.QuickPickItem {
   label: string;

--- a/src/views/jobManager/selfCodes/selfCodesBrowser.ts
+++ b/src/views/jobManager/selfCodes/selfCodesBrowser.ts
@@ -1,5 +1,7 @@
 import * as vscode from 'vscode';
 import { SelfCodeObject } from './selfCodes';
+import { JDBCOptions } from '../../../connection/types';
+import { JobManager } from '../../../config';
 
 export class SelfCodesQuickPickItem implements vscode.QuickPickItem {
   label: string;
@@ -12,6 +14,12 @@ export class SelfCodesQuickPickItem implements vscode.QuickPickItem {
   }
 }
 
-export class SelfCodes {
-  
+export async function setSelfCodes(codes: string[]) {
+  try {
+    await JobManager.runSQL(`SET SYSIBMADM.SELFCODES = SYSIBMADM.VALIDATE_SELF('${codes.join(', ')}')`);
+
+    vscode.window.showInformationMessage(`Applied SELFCODES: ${codes}`);
+  } catch (e) {
+    vscode.window.showErrorMessage(e.message);
+  }
 }

--- a/src/views/jobManager/selfCodes/selfCodesBrowser.ts
+++ b/src/views/jobManager/selfCodes/selfCodesBrowser.ts
@@ -1,0 +1,17 @@
+import * as vscode from 'vscode';
+import { SelfCodeObject } from './selfCodes';
+
+export class SelfCodesQuickPickItem implements vscode.QuickPickItem {
+  label: string;
+  description?: string;
+  detail?: string;
+
+  constructor(object: SelfCodeObject) {
+    this.label = object.code;
+    this.description = object.message;
+  }
+}
+
+export class SelfCodes {
+  
+}

--- a/src/views/jobManager/selfCodes/selfCodesBrowser.ts
+++ b/src/views/jobManager/selfCodes/selfCodesBrowser.ts
@@ -12,13 +12,3 @@ export class SelfCodesQuickPickItem implements vscode.QuickPickItem {
     this.description = object.message;
   }
 }
-
-export async function setSelfCodes(codes: string[]) {
-  try {
-    await JobManager.runSQL(`SET SYSIBMADM.SELFCODES = SYSIBMADM.VALIDATE_SELF('${codes.join(', ')}')`);
-
-    vscode.window.showInformationMessage(`Applied SELF codes: ${codes}`);
-  } catch (e) {
-    vscode.window.showErrorMessage(e.message);
-  }
-}

--- a/src/views/jobManager/selfCodes/selfCodesTest.ts
+++ b/src/views/jobManager/selfCodes/selfCodesTest.ts
@@ -31,7 +31,7 @@ export const selfCodeTests = [
   {
     name: "SQL0203 - C2 without table name",
     code: "203",
-    sql: "SELECT SELFTEST.MYTBL.C2 FROM SELFTEST.MYTBL T1 JOIN SELFTEST.MYTBL2 T2 ON T1.C1 = T2.C1",
+    sql: "SELECT C2 FROM SELFTEST.MYTBL T1 JOIN SELFTEST.MYTBL2 T2 ON T1.C1 = T2.C1",
   },
   {
     name: "SQL0204 - Table doesn't exist",
@@ -80,8 +80,11 @@ export function testSelfCodes(): TestCase[] {
 
         const curJob = JobManager.getRunningJobs();
         curJob[0].job.setSelfCodes([test.code]);
-
-        const result = await JobManager.runSQL(test.sql);
+        try {
+          const result = await JobManager.runSQL(test.sql);
+        } catch (e) {
+          // handle the exception here
+        }
 
         const content = `SELECT * FROM QSYS2.SQL_ERROR_LOG WHERE JOB_NAME = '${curJob[0].job.id}'`;
         const data = await JobManager.runSQL(content);

--- a/src/views/jobManager/selfCodes/selfCodesTest.ts
+++ b/src/views/jobManager/selfCodes/selfCodesTest.ts
@@ -1,0 +1,95 @@
+import { assert } from "vitest";
+import { JobManager } from "../../../config";
+import { TestCase } from "../../../testing";
+
+export const selfCodeTests = [
+  {
+    name: "SQL0138 - Left-most 1001 characters of C2",
+    code: "138",
+    sql: "SELECT LEFT(C2, 1001) FROM SELFTEST.MYTBL",
+  },
+  {
+    name: "SQL0180 - Invalid format for date",
+    code: "180",
+    sql: "VALUES DATE('120-1231-12312')",
+  },
+  {
+    name: "SQL0181 - Date that doesn't exist",
+    code: "181",
+    sql: "VALUES DATE('2023-45-45')",
+  },
+  {
+    name: "SQL0182 - Valid datetime, invalid context",
+    code: "182",
+    sql: "SELECT C3/C4 FROM SELFTEST.MYTBL",
+  },
+  {
+    name: "SQL0199 - Invalid syntax",
+    code: "199",
+    sql: "SELECT * FROM SELFTEST.MYTBL WHERE ORDER BY C1",
+  },
+  {
+    name: "SQL0203 - C2 without table name",
+    code: "203",
+    sql: "SELECT SELFTEST.MYTBL.C2 FROM SELFTEST.MYTBL T1 JOIN SELFTEST.MYTBL2 T2 ON T1.C1 = T2.C1",
+  },
+  {
+    name: "SQL0204 - Table doesn't exist",
+    code: "204",
+    sql: "SELECT * FROM NOEXIST",
+  },
+  {
+    name: "SQL0206 - Column doesn't exist",
+    code: "206",
+    sql: "SELECT NOCOL FROM SELFTEST.MYTBL",
+  },
+  {
+    name: "SQL0420 - Can't cast varchar to int",
+    code: "420",
+    sql: "SELECT CAST(SELFTEST.MYTBL.C2 AS INT) FROM SELFTEST.MYTBL",
+  },
+  // this is a sqpecial case, need to think about how to test this one
+  // {
+  //   name: 'SQL0551 - User profile NOGOOD has no authority',
+  //   code: '551',
+  //   sql: 'CL: CRTUSRPRF USRPRF(NOGOOD); SET SESSION AUTHORIZATION NOGOOD; SELECT * FROM SELFTEST.MYTBL2; DISCONNECT CURRENT; SET SCHEMA SELFTEST; CL: DLTUSRPRF USRPRF(NOGOOD);',
+  // },
+  {
+    name: "SQL0811 - Subquery returns multiple rows",
+    code: "811",
+    sql: "UPDATE SELFTEST.MYTBL SET C1 = (SELECT C1 FROM SELFTEST.MYTBL2)",
+  },
+];
+
+export function testSelfCodes(): TestCase[] {
+  let tests: TestCase[] = [];
+  for (const test of selfCodeTests) {
+    const testCase: TestCase = {
+      name: `Self code Error for test ${test.name}`,
+      test: async () => {
+        // Ensure we have a blank manager first
+        await JobManager.endAll();
+        assert.strictEqual(JobManager.getRunningJobs().length, 0);
+        assert.strictEqual(JobManager.selectedJob, -1);
+
+        // Add a new job
+        await JobManager.newJob();
+
+        // Check the job exists
+        assert.strictEqual(JobManager.getRunningJobs().length, 1);
+
+        const curJob = JobManager.getRunningJobs();
+        curJob[0].job.setSelfCodes([test.code]);
+
+        const result = await JobManager.runSQL(test.sql);
+
+        const content = `SELECT * FROM QSYS2.SQL_ERROR_LOG WHERE JOB_NAME = '${curJob[0].job.id}'`;
+        const data = await JobManager.runSQL(content);
+
+        assert.strictEqual(data.length, 1);
+      },
+    };
+    tests.push(testCase);
+  }
+  return tests;
+}

--- a/src/views/jobManager/statusBar.ts
+++ b/src/views/jobManager/statusBar.ts
@@ -33,6 +33,7 @@ export async function updateStatusBar() {
 
       toolTipItems.push(`[$(info) View Job Log](command:vscode-db2i.jobManager.viewJobLog)`);
       toolTipItems.push(`[$(edit) Edit Connection Settings](command:vscode-db2i.jobManager.editJobProps)`);
+      toolTipItems.push(`[$(bracket-error) Edit SELFCODES](command:vscode-db2i.jobManager.editSelfCodes)`);
     } else {
       text = `$(database) No job active`;
       toolTipItems.push(`[Start Job](command:vscode-db2i.jobManager.newJob)`);

--- a/src/views/jobManager/statusBar.ts
+++ b/src/views/jobManager/statusBar.ts
@@ -33,7 +33,7 @@ export async function updateStatusBar() {
 
       toolTipItems.push(`[$(info) View Job Log](command:vscode-db2i.jobManager.viewJobLog)`);
       toolTipItems.push(`[$(edit) Edit Connection Settings](command:vscode-db2i.jobManager.editJobProps)`);
-      toolTipItems.push(`[$(bracket-error) Edit SELFCODES](command:vscode-db2i.jobManager.editSelfCodes)`);
+      toolTipItems.push(`[$(bracket-error) Edit SELF codes](command:vscode-db2i.jobManager.editSelfCodes)`);
     } else {
       text = `$(database) No job active`;
       toolTipItems.push(`[Start Job](command:vscode-db2i.jobManager.newJob)`);


### PR DESCRIPTION
Test Script:

```sql
-- SETUP, run once
CREATE SCHEMA SELFTEST
CREATE OR REPLACE TABLE SELFTEST.MYTBL (C1 INT, C2 VARCHAR(100), C3 TIMESTAMP, C4 DATE)
CREATE OR REPLACE TABLE SELFTEST.MYTBL2 (C1 INT, C2 VARCHAR(100), C3 TIMESTAMP, C4 DATE)
INSERT INTO SELFTEST.MYTBL VALUES (0, 'ADAM', CURRENT TIMESTAMP, CURRENT DATE)
INSERT INTO SELFTEST.MYTBL VALUES (1, 'LIAM', CURRENT TIMESTAMP + 1 SECOND, CURRENT DATE + 1 DAY)
INSERT INTO SELFTEST.MYTBL VALUES (2, 'RYAN', CURRENT TIMESTAMP + 2 SECOND, CURRENT DATE + 2 DAY)
INSERT INTO SELFTEST.MYTBL VALUES (3, NULL, CURRENT TIMESTAMP + 2 SECOND, CURRENT DATE + 2 DAY)

INSERT INTO SELFTEST.MYTBL2 VALUES (0, 'TIM', CURRENT TIMESTAMP, CURRENT DATE)
INSERT INTO SELFTEST.MYTBL2 VALUES (1, 'SCOTT', CURRENT TIMESTAMP + 1 SECOND, CURRENT DATE + 1 DAY)
INSERT INTO SELFTEST.MYTBL2 VALUES (2, 'JESSIE', CURRENT TIMESTAMP + 2 SECOND, CURRENT DATE + 2 DAY)
STOP

SET SCHEMA SELFTEST

-- SQL0138, get left-most 1001 characters of C2. C2 is only 100 characters long, so SQL0138 is produced
SELECT LEFT(C2, 1001) FROM SELFTEST.MYTBL

-- SQL0180, invalid format for date given
VALUES DATE('120-1231-12312')

-- SQL0181, valid format for date given, but the date doesn't exist
VALUES DATE('2023-45-45')

-- SQL0182, valid datetime exists, but context in which the timestamp is used is invalid (dividing int by timestamp doesn't make sense)
SELECT C3/C4 FROM SELFTEST.MYTBL

-- SQL0199, invalid syntax, missing predicate after WHERE and before ORDER BY
SELECT * FROM SELFTEST.MYTBL WHERE ORDER BY C1

-- SQL0203, C2 doesn't have a table name associated with it (T1 or T2), the database doesn't know what C2 to select
SELECT SELFTEST.MYTBL.C2 FROM SELFTEST.MYTBL T1
JOIN SELFTEST.MYTBL2 T2 ON
T1.C1 = T2.C1

-- SQL0204, trying to select from a table that doesn't exist
SELECT * FROM NOEXIST

-- SQL0206, column doesn't exist (but the table does)
SELECT NOCOL FROM SELFTEST.MYTBL

-- SQL0420, can't cast varchar to int
SELECT CAST(SELFTEST.MYTBL.C2 AS INT) FROM SELFTEST.MYTBL

-- SQL0551, user profile NOGOOD has no authority to access database file
CL: CRTUSRPRF USRPRF(NOGOOD)
SET SESSION AUTHORIZATION NOGOOD -- Swap to user profile with no permissions
SELECT * FROM SELFTEST.MYTBL2

DISCONNECT CURRENT -- Can't swap back to your normal profile once you've given up permissions, need to disconnect and reconnect
SET SCHEMA SELFTEST
CL: DLTUSRPRF USRPRF(NOGOOD) -- Clean up

-- SQL0811, subquery in update returns multiple rows, database doesn't know what row to use for update. Subquery must be correlated
UPDATE SELFTEST.MYTBL SET C1 = (SELECT C1 FROM SELFTEST.MYTBL2)




```