### PR TITLE
Update SQL formatter and allow SQL keyword in lower- or uppercase

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "lru-cache": "^6.0.0",
         "node-fetch": "^3.3.1",
         "octokit": "^2.0.14",
-        "sql-formatter": "^4.0.2"
+        "sql-formatter": "^12.2.4"
       },
       "devDependencies": {
         "@halcyontech/vscode-ibmi-types": "^2.0.0",
@@ -1767,8 +1767,7 @@
     "node_modules/commander": {
       "version": "2.20.3",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-      "dev": true
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
@@ -1881,6 +1880,11 @@
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
+    },
+    "node_modules/discontinuous-range": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/discontinuous-range/-/discontinuous-range-1.0.0.tgz",
+      "integrity": "sha512-c68LpLbO+7kP/b1Hr1qs8/BJ09F5khZGTxqxZuhzxpmwJKOgRFHJWIb9/KmqnqHhLdO55aOxFH/EGBvUQbL/RQ=="
     },
     "node_modules/doctrine": {
       "version": "3.0.0",
@@ -2477,6 +2481,17 @@
       "dev": true,
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/get-stdin": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-8.0.0.tgz",
+      "integrity": "sha512-sY22aA6xchAzprjyqmSEQv4UbAAzRN0L2dQB0NlN5acTTK9Don6nhoc3eAbUnpZiCANAMfd/+40kVdKfFygohg==",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/get-stream": {
@@ -3140,6 +3155,11 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/moo": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/moo/-/moo-0.5.2.tgz",
+      "integrity": "sha512-iSAJLHYKnX41mKcJKjqvnAN9sf0LMDTXDEvFv+ffuRR9a1MIuXLjMNL6EsnDHSkKLTWNqQQ5uo61P4EbU4NU+Q=="
+    },
     "node_modules/ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
@@ -3168,6 +3188,27 @@
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
       "dev": true
+    },
+    "node_modules/nearley": {
+      "version": "2.20.1",
+      "resolved": "https://registry.npmjs.org/nearley/-/nearley-2.20.1.tgz",
+      "integrity": "sha512-+Mc8UaAebFzgV+KpI5n7DasuuQCHA89dmwm7JXw3TV43ukfNQ9DnBH3Mdb2g/I4Fdxc26pwimBWvjIw0UAILSQ==",
+      "dependencies": {
+        "commander": "^2.19.0",
+        "moo": "^0.5.0",
+        "railroad-diagrams": "^1.0.0",
+        "randexp": "0.4.6"
+      },
+      "bin": {
+        "nearley-railroad": "bin/nearley-railroad.js",
+        "nearley-test": "bin/nearley-test.js",
+        "nearley-unparse": "bin/nearley-unparse.js",
+        "nearleyc": "bin/nearleyc.js"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://nearley.js.org/#give-to-nearley"
+      }
     },
     "node_modules/neo-async": {
       "version": "2.6.2",
@@ -3550,6 +3591,23 @@
         "node": ">=6"
       }
     },
+    "node_modules/railroad-diagrams": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/railroad-diagrams/-/railroad-diagrams-1.0.0.tgz",
+      "integrity": "sha512-cz93DjNeLY0idrCNOH6PviZGRN9GJhsdm9hpn1YCS879fj4W+x5IFJhhkRZcwVgMmFF7R82UA/7Oh+R8lLZg6A=="
+    },
+    "node_modules/randexp": {
+      "version": "0.4.6",
+      "resolved": "https://registry.npmjs.org/randexp/-/randexp-0.4.6.tgz",
+      "integrity": "sha512-80WNmd9DA0tmZrw9qQa62GPPWfuXJknrmVmLcxvq4uZBdYqb1wYoKTmnlGUchvVWe0XiLupYkBoXVOxz3C8DYQ==",
+      "dependencies": {
+        "discontinuous-range": "1.0.0",
+        "ret": "~0.1.10"
+      },
+      "engines": {
+        "node": ">=0.12"
+      }
+    },
     "node_modules/randombytes": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
@@ -3684,6 +3742,14 @@
       "dev": true,
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/ret": {
+      "version": "0.1.15",
+      "resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
+      "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==",
+      "engines": {
+        "node": ">=0.12"
       }
     },
     "node_modules/rimraf": {
@@ -3877,14 +3943,16 @@
       "dev": true
     },
     "node_modules/sql-formatter": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/sql-formatter/-/sql-formatter-4.0.2.tgz",
-      "integrity": "sha512-R6u9GJRiXZLr/lDo8p56L+OyyN2QFJPCDnsyEOsbdIpsnDKL8gubYFo7lNR7Zx7hfdWT80SfkoVS0CMaF/DE2w==",
+      "version": "12.2.4",
+      "resolved": "https://registry.npmjs.org/sql-formatter/-/sql-formatter-12.2.4.tgz",
+      "integrity": "sha512-Qj45LEHSfgrdYDOrAtIkR8SdS10SWcqCIM2WZwQwMKF2v9sM0K2dlThWPS7eYCUrhttZIrU1WwuIwHk7MjsWOw==",
       "dependencies": {
-        "argparse": "^2.0.1"
+        "argparse": "^2.0.1",
+        "get-stdin": "=8.0.0",
+        "nearley": "^2.20.1"
       },
       "bin": {
-        "sql-formatter": "bin/sqlfmt.js"
+        "sql-formatter": "bin/sql-formatter-cli.cjs"
       }
     },
     "node_modules/sql-formatter/node_modules/argparse": {
@@ -6396,8 +6464,7 @@
     "commander": {
       "version": "2.20.3",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-      "dev": true
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
     },
     "concat-map": {
       "version": "0.0.1",
@@ -6487,6 +6554,11 @@
       "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-29.6.3.tgz",
       "integrity": "sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==",
       "dev": true
+    },
+    "discontinuous-range": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/discontinuous-range/-/discontinuous-range-1.0.0.tgz",
+      "integrity": "sha512-c68LpLbO+7kP/b1Hr1qs8/BJ09F5khZGTxqxZuhzxpmwJKOgRFHJWIb9/KmqnqHhLdO55aOxFH/EGBvUQbL/RQ=="
     },
     "doctrine": {
       "version": "3.0.0",
@@ -6937,6 +7009,11 @@
       "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.2.tgz",
       "integrity": "sha512-8vXOvuE167CtIc3OyItco7N/dpRtBbYOsPsXCz7X/PMnlGjYjSGuZJgM1Y7mmew7BKf9BqvLX2tnOVy1BBUsxQ==",
       "dev": true
+    },
+    "get-stdin": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-8.0.0.tgz",
+      "integrity": "sha512-sY22aA6xchAzprjyqmSEQv4UbAAzRN0L2dQB0NlN5acTTK9Don6nhoc3eAbUnpZiCANAMfd/+40kVdKfFygohg=="
     },
     "get-stream": {
       "version": "6.0.1",
@@ -7437,6 +7514,11 @@
         }
       }
     },
+    "moo": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/moo/-/moo-0.5.2.tgz",
+      "integrity": "sha512-iSAJLHYKnX41mKcJKjqvnAN9sf0LMDTXDEvFv+ffuRR9a1MIuXLjMNL6EsnDHSkKLTWNqQQ5uo61P4EbU4NU+Q=="
+    },
     "ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
@@ -7453,6 +7535,17 @@
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
       "dev": true
+    },
+    "nearley": {
+      "version": "2.20.1",
+      "resolved": "https://registry.npmjs.org/nearley/-/nearley-2.20.1.tgz",
+      "integrity": "sha512-+Mc8UaAebFzgV+KpI5n7DasuuQCHA89dmwm7JXw3TV43ukfNQ9DnBH3Mdb2g/I4Fdxc26pwimBWvjIw0UAILSQ==",
+      "requires": {
+        "commander": "^2.19.0",
+        "moo": "^0.5.0",
+        "railroad-diagrams": "^1.0.0",
+        "randexp": "0.4.6"
+      }
     },
     "neo-async": {
       "version": "2.6.2",
@@ -7721,6 +7814,20 @@
       "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
       "dev": true
     },
+    "railroad-diagrams": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/railroad-diagrams/-/railroad-diagrams-1.0.0.tgz",
+      "integrity": "sha512-cz93DjNeLY0idrCNOH6PviZGRN9GJhsdm9hpn1YCS879fj4W+x5IFJhhkRZcwVgMmFF7R82UA/7Oh+R8lLZg6A=="
+    },
+    "randexp": {
+      "version": "0.4.6",
+      "resolved": "https://registry.npmjs.org/randexp/-/randexp-0.4.6.tgz",
+      "integrity": "sha512-80WNmd9DA0tmZrw9qQa62GPPWfuXJknrmVmLcxvq4uZBdYqb1wYoKTmnlGUchvVWe0XiLupYkBoXVOxz3C8DYQ==",
+      "requires": {
+        "discontinuous-range": "1.0.0",
+        "ret": "~0.1.10"
+      }
+    },
     "randombytes": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
@@ -7823,6 +7930,11 @@
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
       "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
       "dev": true
+    },
+    "ret": {
+      "version": "0.1.15",
+      "resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
+      "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg=="
     },
     "rimraf": {
       "version": "3.0.2",
@@ -7954,11 +8066,13 @@
       "dev": true
     },
     "sql-formatter": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/sql-formatter/-/sql-formatter-4.0.2.tgz",
-      "integrity": "sha512-R6u9GJRiXZLr/lDo8p56L+OyyN2QFJPCDnsyEOsbdIpsnDKL8gubYFo7lNR7Zx7hfdWT80SfkoVS0CMaF/DE2w==",
+      "version": "12.2.4",
+      "resolved": "https://registry.npmjs.org/sql-formatter/-/sql-formatter-12.2.4.tgz",
+      "integrity": "sha512-Qj45LEHSfgrdYDOrAtIkR8SdS10SWcqCIM2WZwQwMKF2v9sM0K2dlThWPS7eYCUrhttZIrU1WwuIwHk7MjsWOw==",
       "requires": {
-        "argparse": "^2.0.1"
+        "argparse": "^2.0.1",
+        "get-stdin": "=8.0.0",
+        "nearley": "^2.20.1"
       },
       "dependencies": {
         "argparse": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "lru-cache": "^6.0.0",
         "node-fetch": "^3.3.1",
         "octokit": "^2.0.14",
-        "sql-formatter": "^13.0.4"
+        "sql-formatter": "^13.1.0"
       },
       "devDependencies": {
         "@halcyontech/vscode-ibmi-types": "^2.0.0",
@@ -3943,9 +3943,9 @@
       "dev": true
     },
     "node_modules/sql-formatter": {
-      "version": "13.0.4",
-      "resolved": "https://registry.npmjs.org/sql-formatter/-/sql-formatter-13.0.4.tgz",
-      "integrity": "sha512-6pns27iQ5yT8jmle4cqvpfXNl29/AGOT4KtmzhtI2zgH1J0RbpZdduqTRzem7UCta+gvrj4HC1O9l6mTSUHoRg==",
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/sql-formatter/-/sql-formatter-13.1.0.tgz",
+      "integrity": "sha512-/nZQXuN7KzipFNM20ko+dHY4kOr9rymSfZLUDED8rhx3m8OK5y74jcyN+y1L51ZqHqiB0kp40VdpZP99uWvQdA==",
       "dependencies": {
         "argparse": "^2.0.1",
         "get-stdin": "=8.0.0",
@@ -8066,9 +8066,9 @@
       "dev": true
     },
     "sql-formatter": {
-      "version": "13.0.4",
-      "resolved": "https://registry.npmjs.org/sql-formatter/-/sql-formatter-13.0.4.tgz",
-      "integrity": "sha512-6pns27iQ5yT8jmle4cqvpfXNl29/AGOT4KtmzhtI2zgH1J0RbpZdduqTRzem7UCta+gvrj4HC1O9l6mTSUHoRg==",
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/sql-formatter/-/sql-formatter-13.1.0.tgz",
+      "integrity": "sha512-/nZQXuN7KzipFNM20ko+dHY4kOr9rymSfZLUDED8rhx3m8OK5y74jcyN+y1L51ZqHqiB0kp40VdpZP99uWvQdA==",
       "requires": {
         "argparse": "^2.0.1",
         "get-stdin": "=8.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "lru-cache": "^6.0.0",
         "node-fetch": "^3.3.1",
         "octokit": "^2.0.14",
-        "sql-formatter": "^12.2.4"
+        "sql-formatter": "^13.0.4"
       },
       "devDependencies": {
         "@halcyontech/vscode-ibmi-types": "^2.0.0",
@@ -3943,9 +3943,9 @@
       "dev": true
     },
     "node_modules/sql-formatter": {
-      "version": "12.2.4",
-      "resolved": "https://registry.npmjs.org/sql-formatter/-/sql-formatter-12.2.4.tgz",
-      "integrity": "sha512-Qj45LEHSfgrdYDOrAtIkR8SdS10SWcqCIM2WZwQwMKF2v9sM0K2dlThWPS7eYCUrhttZIrU1WwuIwHk7MjsWOw==",
+      "version": "13.0.4",
+      "resolved": "https://registry.npmjs.org/sql-formatter/-/sql-formatter-13.0.4.tgz",
+      "integrity": "sha512-6pns27iQ5yT8jmle4cqvpfXNl29/AGOT4KtmzhtI2zgH1J0RbpZdduqTRzem7UCta+gvrj4HC1O9l6mTSUHoRg==",
       "dependencies": {
         "argparse": "^2.0.1",
         "get-stdin": "=8.0.0",
@@ -8066,9 +8066,9 @@
       "dev": true
     },
     "sql-formatter": {
-      "version": "12.2.4",
-      "resolved": "https://registry.npmjs.org/sql-formatter/-/sql-formatter-12.2.4.tgz",
-      "integrity": "sha512-Qj45LEHSfgrdYDOrAtIkR8SdS10SWcqCIM2WZwQwMKF2v9sM0K2dlThWPS7eYCUrhttZIrU1WwuIwHk7MjsWOw==",
+      "version": "13.0.4",
+      "resolved": "https://registry.npmjs.org/sql-formatter/-/sql-formatter-13.0.4.tgz",
+      "integrity": "sha512-6pns27iQ5yT8jmle4cqvpfXNl29/AGOT4KtmzhtI2zgH1J0RbpZdduqTRzem7UCta+gvrj4HC1O9l6mTSUHoRg==",
       "requires": {
         "argparse": "^2.0.1",
         "get-stdin": "=8.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vscode-db2i",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "vscode-db2i",
-      "version": "0.5.1",
+      "version": "0.5.2",
       "dependencies": {
         "csv": "^6.1.3",
         "lru-cache": "^6.0.0",

--- a/package.json
+++ b/package.json
@@ -598,7 +598,7 @@
     "csv": "^6.1.3",
     "node-fetch": "^3.3.1",
     "octokit": "^2.0.14",
-    "sql-formatter": "^12.2.4",
+    "sql-formatter": "^13.0.4",
     "lru-cache": "^6.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -588,7 +588,7 @@
     "csv": "^6.1.3",
     "node-fetch": "^3.3.1",
     "octokit": "^2.0.14",
-    "sql-formatter": "^4.0.2",
+    "sql-formatter": "^12.2.4",
     "lru-cache": "^6.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -598,7 +598,7 @@
     "csv": "^6.1.3",
     "node-fetch": "^3.3.1",
     "octokit": "^2.0.14",
-    "sql-formatter": "^13.0.4",
+    "sql-formatter": "^13.1.0",
     "lru-cache": "^6.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -65,6 +65,16 @@
           "description": "Saved configs for",
           "default": {},
           "additionalProperties": true
+        },
+        "vscode-db2i.sqlFormat.keywordCase": {
+          "type": "string",
+          "description": "SQL formatting options: Lowercase or uppercase SQL keywords",
+          "default": "lower",
+          "enum": ["lower", "upper"],
+          "enumDescriptions": [
+            "Format reserved SQL keywords in lowercase",
+            "Format reserved SQL keywords in uppercase"
+          ]
         }
       }
     },

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -1,17 +1,19 @@
 
 import vscode from "vscode";
 
+const getConfiguration = (): vscode.WorkspaceConfiguration => {
+  return vscode.workspace.getConfiguration(`vscode-db2i`);
+}
+
 export default class Configuration {
   /**
    * Returns variable not specific to a host (e.g. a global config)
    */
   static get<T>(prop: string) {
-    const globalData = vscode.workspace.getConfiguration(`vscode-db2i`);
-    return globalData.get<T>(prop);
+    return getConfiguration().get<T>(prop);
   }
 
   static set(prop: string, newValue: any) {
-    const globalData = vscode.workspace.getConfiguration(`vscode-db2i`);
-    return globalData.update(prop, newValue, true);
+    return getConfiguration().update(prop, newValue, true);
   }
 }

--- a/src/database/statement.ts
+++ b/src/database/statement.ts
@@ -8,6 +8,7 @@ export default class Statement {
     return format(sql, {
       language: `db2`, // Defaults to "sql" (see the above list of supported dialects)
       linesBetweenQueries: 2, // Defaults to 1
+      keywordCase: "lower"
     });
   }
 

--- a/src/database/statement.ts
+++ b/src/database/statement.ts
@@ -1,14 +1,16 @@
 
 import { getInstance } from "../base";
+import Configuration from "../configuration";
 
-import {format} from "sql-formatter"
+import {format, KeywordCase} from "sql-formatter"
 
 export default class Statement {
   static format(sql: string) {
+    const keywordCase: KeywordCase = <KeywordCase>(Configuration.get(`sqlFormat.keywordCase`) || `lower`);
     return format(sql, {
       language: `db2`, // Defaults to "sql" (see the above list of supported dialects)
       linesBetweenQueries: 2, // Defaults to 1
-      keywordCase: "lower"
+      keywordCase: keywordCase
     });
   }
 

--- a/src/database/statement.ts
+++ b/src/database/statement.ts
@@ -8,7 +8,7 @@ export default class Statement {
   static format(sql: string) {
     const keywordCase: KeywordCase = <KeywordCase>(Configuration.get(`sqlFormat.keywordCase`) || `lower`);
     return format(sql, {
-      language: `db2`, // Defaults to "sql" (see the above list of supported dialects)
+      language: `db2i`, // Defaults to "sql" (see the above list of supported dialects)
       linesBetweenQueries: 2, // Defaults to 1
       keywordCase: keywordCase
     });


### PR DESCRIPTION
This PR will
- update the [SQL formatter](https://github.com/sql-formatter-org/sql-formatter) to the current version of 13.1.0
- use the new language `db2i` implemented in SQL Formatter version 13.1.0
- add a configuration value `sqlFormat.keywordCase` to allow the user to have SQL keywords in lower- or uppercase

With this PR and a configuration setting of `lower`, the generated SQL for `QGPL.QAIDRKEYS` will be like this:

![image](https://github.com/codefori/vscode-db2i/assets/13275072/e450d17c-aa8d-4afa-abcd-e3377cf50bc6)

Before this would be formatted like this:

![image](https://github.com/codefori/vscode-db2i/assets/13275072/1c30ea39-318a-4984-87a4-b944cc85dd13)
