### PR TITLE
Add new format provider

### DIFF
--- a/src/database/statement.ts
+++ b/src/database/statement.ts
@@ -2,12 +2,13 @@
 import { getInstance } from "../base";
 import Configuration from "../configuration";
 
-import {format, KeywordCase} from "sql-formatter"
+import {format, FormatOptionsWithLanguage, KeywordCase} from "sql-formatter"
 
 export default class Statement {
-  static format(sql: string) {
+  static format(sql: string, options: FormatOptionsWithLanguage = {}) {
     const keywordCase: KeywordCase = <KeywordCase>(Configuration.get(`sqlFormat.keywordCase`) || `lower`);
     return format(sql, {
+      ...options,
       language: `db2i`, // Defaults to "sql" (see the above list of supported dialects)
       linesBetweenQueries: 2, // Defaults to 1
       keywordCase: keywordCase

--- a/src/language/index.ts
+++ b/src/language/index.ts
@@ -1,10 +1,12 @@
 import { completionProvider } from "./providers/completionProvider";
+import { formatProvider } from "./providers/formatProvider";
 
 export function languageInit() {
   let functionality = [];
 
   functionality.push(
-    completionProvider
+    completionProvider,
+    formatProvider
   );
   
   return functionality;

--- a/src/language/providers/formatProvider.ts
+++ b/src/language/providers/formatProvider.ts
@@ -1,0 +1,19 @@
+import { Position, Range, TextEdit, languages } from "vscode";
+import Statement from "../../database/statement";
+
+export const formatProvider = languages.registerDocumentFormattingEditProvider({language: `sql`}, {
+  async provideDocumentFormattingEdits(document, options, token) {
+    const formatted = Statement.format(
+      document.getText(), 
+      {
+        useTabs: !options.insertSpaces,
+        tabWidth: options.tabSize,
+      }
+    );
+
+    return [new TextEdit(
+      new Range(0, 0, Number.MAX_SAFE_INTEGER, Number.MAX_SAFE_INTEGER),
+      formatted
+    )];
+  }
+})


### PR DESCRIPTION
Since we have a nicer SQL formatter now, I have decided to add a format provider which enables the standard 'Format Document' to work with SQL sources.