### PR TITLE
Add SQL identifier case - new in SQL formatter 14.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "lru-cache": "^6.0.0",
         "node-fetch": "^3.3.1",
         "octokit": "^2.0.14",
-        "sql-formatter": "^13.1.0"
+        "sql-formatter": "^14.0.0"
       },
       "devDependencies": {
         "@halcyontech/vscode-ibmi-types": "^2.0.0",
@@ -3943,9 +3943,9 @@
       "dev": true
     },
     "node_modules/sql-formatter": {
-      "version": "13.1.0",
-      "resolved": "https://registry.npmjs.org/sql-formatter/-/sql-formatter-13.1.0.tgz",
-      "integrity": "sha512-/nZQXuN7KzipFNM20ko+dHY4kOr9rymSfZLUDED8rhx3m8OK5y74jcyN+y1L51ZqHqiB0kp40VdpZP99uWvQdA==",
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/sql-formatter/-/sql-formatter-14.0.0.tgz",
+      "integrity": "sha512-VcHYMRvZqg3RNjjxNB/puT9O1hR5QLXTvgTaBtxXcvmRQwSnH9M+oW2Ti+uFuVVU8HoNlOjU2uKHv8c0FQNsdQ==",
       "dependencies": {
         "argparse": "^2.0.1",
         "get-stdin": "=8.0.0",
@@ -8066,9 +8066,9 @@
       "dev": true
     },
     "sql-formatter": {
-      "version": "13.1.0",
-      "resolved": "https://registry.npmjs.org/sql-formatter/-/sql-formatter-13.1.0.tgz",
-      "integrity": "sha512-/nZQXuN7KzipFNM20ko+dHY4kOr9rymSfZLUDED8rhx3m8OK5y74jcyN+y1L51ZqHqiB0kp40VdpZP99uWvQdA==",
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/sql-formatter/-/sql-formatter-14.0.0.tgz",
+      "integrity": "sha512-VcHYMRvZqg3RNjjxNB/puT9O1hR5QLXTvgTaBtxXcvmRQwSnH9M+oW2Ti+uFuVVU8HoNlOjU2uKHv8c0FQNsdQ==",
       "requires": {
         "argparse": "^2.0.1",
         "get-stdin": "=8.0.0",

--- a/package.json
+++ b/package.json
@@ -66,6 +66,17 @@
           "default": {},
           "additionalProperties": true
         },
+        "vscode-db2i.sqlFormat.identifierCase": {
+          "type": "string",
+          "description": "SQL formatting options: Lowercase or uppercase SQL identifiers",
+          "default": "preserve",
+          "enum": ["lower", "upper", "preserve"],
+          "enumDescriptions": [
+            "Format SQL identifiers in lowercase",
+            "Format SQL identifiers in uppercase",
+            "Preserve the current formatting of SQL identifiers"
+          ]
+        },
         "vscode-db2i.sqlFormat.keywordCase": {
           "type": "string",
           "description": "SQL formatting options: Lowercase or uppercase SQL keywords",
@@ -598,7 +609,7 @@
     "csv": "^6.1.3",
     "node-fetch": "^3.3.1",
     "octokit": "^2.0.14",
-    "sql-formatter": "^13.1.0",
+    "sql-formatter": "^14.0.0",
     "lru-cache": "^6.0.0"
   }
 }

--- a/src/database/statement.ts
+++ b/src/database/statement.ts
@@ -2,16 +2,18 @@
 import { getInstance } from "../base";
 import Configuration from "../configuration";
 
-import {format, FormatOptionsWithLanguage, KeywordCase} from "sql-formatter"
+import {format, FormatOptionsWithLanguage, IdentifierCase, KeywordCase} from "sql-formatter"
 
 export default class Statement {
   static format(sql: string, options: FormatOptionsWithLanguage = {}) {
+    const identifierCase: IdentifierCase = <IdentifierCase>(Configuration.get(`sqlFormat.identifierCase`) || `preserve`);
     const keywordCase: KeywordCase = <KeywordCase>(Configuration.get(`sqlFormat.keywordCase`) || `lower`);
     return format(sql, {
       ...options,
       language: `db2i`, // Defaults to "sql" (see the above list of supported dialects)
       linesBetweenQueries: 2, // Defaults to 1
-      keywordCase: keywordCase
+      identifierCase: identifierCase,
+      keywordCase: keywordCase,
     });
   }
 


### PR DESCRIPTION
This PR will
- update SQL formatter to version 14.0.0, which includes the new option for identifier formatting
- add a configuration value `sqlFormat.identifierCase` to allow the user to have SQL identifier in lower- or uppercase or not changed. Default is `preserve` to not change the identifier case unintentionally.

With this support the following SQL statement

![image](https://github.com/codefori/vscode-db2i/assets/13275072/d4282815-7579-48ad-9b75-3309d48fd181)

will be formatted like this (with identifiers set to uppercase and keywords to lowercase):

![image](https://github.com/codefori/vscode-db2i/assets/13275072/2732fea4-609f-40eb-8f13-4c426f8606e9)
