### PR TITLE
Reset the results view on disconnect

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -71,6 +71,8 @@ export function setupConfig(context: ExtensionContext) {
 
     // Remove old service examples
     delete Examples[ServiceInfoLabel];
+    
+    await commands.executeCommand(`vscode-db2i.resultset.reset`);
   });
 }
 

--- a/src/views/results/index.ts
+++ b/src/views/results/index.ts
@@ -95,7 +95,7 @@ class ResultSetPanelProvider {
     }
   }
 
-  async setLoadingText(content) {
+  async setLoadingText(content: string) {
     await this.focus();
 
     if (!this.loadingState) {
@@ -146,6 +146,11 @@ export function initialise(context: vscode.ExtensionContext) {
   context.subscriptions.push(
     vscode.window.registerWebviewViewProvider(`vscode-db2i.resultset`, resultSetProvider, {
       webviewOptions: { retainContextWhenHidden: true },
+    }),
+
+    vscode.commands.registerCommand(`vscode-db2i.resultset.reset`, async () => {
+      resultSetProvider.loadingState = false;
+      resultSetProvider.setLoadingText(`View will be active when a statement is executed.`);
     }),
 
     vscode.commands.registerCommand(`vscode-db2i.runEditorStatement`,


### PR DESCRIPTION
Fixes #174.

Will reset the results view when disconnecting from a system so it is back to normal when connecting to a new system.