### PR TITLE
Fix issue with DECLARE blocks not being considered

### DIFF
--- a/src/language/sql/statement.ts
+++ b/src/language/sql/statement.ts
@@ -41,7 +41,8 @@ export default class Statement {
 			return true;
 		}
 
-		if (this.type === StatementType.Create) {
+		// These statements can end with BEGIN, which signifies a block starter
+		if ([StatementType.Create, StatementType.Declare].includes(this.type)) {
 			const last = this.tokens[this.tokens.length-1];
 			if (tokenIs(last, `keyword`, `BEGIN`)) {
 				return true;


### PR DESCRIPTION
Fixes issue where a DECLARE block (`DECLARE .. BEGIN`) was not being considered when parsing statements.