### PR TITLE
Examples browser cleanup

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vscode-db2i",
-  "version": "0.5.2",
+  "version": "0.6.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "vscode-db2i",
-      "version": "0.5.2",
+      "version": "0.6.0",
       "dependencies": {
         "csv": "^6.1.3",
         "lru-cache": "^6.0.0",

--- a/package.json
+++ b/package.json
@@ -75,7 +75,11 @@
           "type": "string",
           "description": "SQL formatting options: Lowercase or uppercase SQL identifiers",
           "default": "preserve",
-          "enum": ["lower", "upper", "preserve"],
+          "enum": [
+            "lower",
+            "upper",
+            "preserve"
+          ],
           "enumDescriptions": [
             "Format SQL identifiers in lowercase",
             "Format SQL identifiers in uppercase",
@@ -86,7 +90,10 @@
           "type": "string",
           "description": "SQL formatting options: Lowercase or uppercase SQL keywords",
           "default": "lower",
-          "enum": ["lower", "upper"],
+          "enum": [
+            "lower",
+            "upper"
+          ],
           "enumDescriptions": [
             "Format reserved SQL keywords in lowercase",
             "Format reserved SQL keywords in uppercase"
@@ -292,6 +299,12 @@
         "icon": "$(clear-all)"
       },
       {
+        "command": "vscode-db2i.examples.reload",
+        "title": "Reload examples",
+        "category": "Db2 for i",
+        "icon": "$(sync)"
+      },
+      {
         "command": "vscode-db2i.jobManager.newJob",
         "title": "New SQL Job",
         "category": "Db2 for i",
@@ -420,6 +433,10 @@
         {
           "command": "vscode-db2i.jobManager.deleteConfig",
           "when": "never"
+        },
+        {
+          "command": "vscode-db2i.examples.reload",
+          "when": "never"
         }
       ],
       "editor/context": [
@@ -466,7 +483,12 @@
           "command": "vscode-db2i.examples.clearFilter",
           "group": "navigation",
           "when": "view == exampleBrowser"
-        },
+        },        
+        {
+          "command": "vscode-db2i.examples.reload",
+          "group": "navigation@99",
+          "when": "view == exampleBrowser"
+        },        
         {
           "command": "vscode-db2i.openSqlDocument",
           "group": "navigation",

--- a/src/database/serviceInfo.ts
+++ b/src/database/serviceInfo.ts
@@ -1,17 +1,17 @@
-import { SQLExample } from "../views/examples";
 import { JobManager } from "../config";
+import { SQLExample } from "../views/examples";
 import Statement from "./statement";
 
-export async function getServiceInfo(): Promise<SQLExample[]|undefined> {
+export async function getServiceInfo(): Promise<SQLExample[]> {
   // The reason we check for a selection is because we don't want it to prompt the user to start one here
   if (JobManager.getSelection()) {
-    const resultSet = await JobManager.runSQL<{SERVICE_NAME: string, EXAMPLE: string}>(`select SERVICE_NAME, EXAMPLE from qsys2.services_info`);
+    const resultSet = await JobManager.runSQL<{ SERVICE_NAME: string, EXAMPLE: string }>(`select SERVICE_NAME, EXAMPLE from qsys2.services_info`);
 
     return resultSet.map(r => ({
       name: Statement.prettyName(r.SERVICE_NAME),
       content: [r.EXAMPLE],
     }))
   } else {
-    return undefined;
+    return [{ name: "Please start an SQL job to load the examples", content: [""] }];
   }
 }

--- a/src/views/examples/exampleBrowser.ts
+++ b/src/views/examples/exampleBrowser.ts
@@ -38,6 +38,11 @@ export class ExampleBrowser implements TreeDataProvider<any> {
       commands.registerCommand(`vscode-db2i.examples.clearFilter`, async () => {
         this.currentFilter = undefined;
         this.refresh();
+      }),
+
+      commands.registerCommand("vscode-db2i.examples.reload", () => {
+        delete Examples[ServiceInfoLabel];
+        this.refresh();
       })
     );
 

--- a/src/views/examples/exampleBrowser.ts
+++ b/src/views/examples/exampleBrowser.ts
@@ -1,4 +1,4 @@
-import { Event, EventEmitter, ExtensionContext, MarkdownString, ThemeIcon, TreeDataProvider, TreeItem, TreeItemCollapsibleState, commands, window, workspace } from "vscode";
+import { Event, EventEmitter, ExtensionContext, MarkdownString, ThemeIcon, TreeDataProvider, TreeItem, TreeItemCollapsibleState, Uri, commands, window, workspace } from "vscode";
 import { Examples, SQLExample, ServiceInfoLabel } from ".";
 import { getInstance } from "../../base";
 import { OSData, fetchSystemInfo } from "../../config";
@@ -109,7 +109,7 @@ class SQLExampleItem extends TreeItem {
   constructor(example: SQLExample) {
     super(example.name, TreeItemCollapsibleState.None);
     this.iconPath = ThemeIcon.File;
-
+    this.resourceUri = Uri.parse('_.sql');
     this.tooltip = new MarkdownString(['```sql', example.content.join(`\n`), '```'].join(`\n`));
 
     this.command = {

--- a/src/views/examples/exampleBrowser.ts
+++ b/src/views/examples/exampleBrowser.ts
@@ -79,10 +79,13 @@ export class ExampleBrowser implements TreeDataProvider<any> {
         return Object.values(Examples)
           .flatMap(examples => examples.filter(exampleWorksForOnOS))
           .filter(example => example.name.toUpperCase().includes(upperFilter) || example.content.some(line => line.toUpperCase().includes(upperFilter)))
+          .sort(sort)
           .map(example => new SQLExampleItem(example));
       }
       else {
-        return Object.entries(Examples).map(([name, examples]) => new ExampleGroupItem(name, examples));
+        return Object.entries(Examples)
+          .sort(([name1], [name2]) => sort(name1, name2))
+          .map(([name, examples]) => new ExampleGroupItem(name, examples));
       }
     }
   }
@@ -97,6 +100,7 @@ class ExampleGroupItem extends TreeItem {
   getChildren(): SQLExampleItem[] {
     return this.group
       .filter(example => exampleWorksForOnOS(example))
+      .sort(sort)
       .map(example => new SQLExampleItem(example));
   }
 }
@@ -129,4 +133,10 @@ function exampleWorksForOnOS(example: SQLExample): boolean {
   }
 
   return true;
+}
+
+function sort(string1: string | SQLExample, string2: string | SQLExample) {
+  string1 = typeof string1 === "string" ? string1 : string1.name;
+  string2 = typeof string2 === "string" ? string2 : string2.name;
+  return string1.localeCompare(string2);
 }

--- a/src/views/examples/index.ts
+++ b/src/views/examples/index.ts
@@ -13,10 +13,10 @@ export interface SQLExample {
   requirements?: ExampleSystemRequirements;
 };
 
-    // Unlike the bulk of the examples defined below, the services examples are retrieved dynamically
-    export const ServiceInfoLabel = `IBM i (SQL) Services`;
+// Unlike the bulk of the examples defined below, the services examples are retrieved dynamically
+export const ServiceInfoLabel = `IBM i (SQL) Services`;
 
-export let Examples: SQLExamplesList = {
+export const Examples: SQLExamplesList = {
   "Data Definition Language (DDL)": [
     {
       "name": "Create Schema",


### PR DESCRIPTION
I noticed that the Examples browser looped when loading if no SQL job was started, because loading the Services called `refresh` which in turn called `getChildren`...and if the Services are still undefined (because no SQL job), then it loops.

So this PR fixes that. Loading the Services example doesn't call `refresh` anymore (it wasn't needed in the first place), and an information item is displayed under the Service folder to ask for an SQL job.

A `Reload` was added to the browser to allow to reload the Services example if needed.

The Examples are now sorted alphabetically and their icon is the SQL file's.