### PR TITLE
fix: use bash to run `mkdir -p` for `npm run dsc`

### DIFF
--- a/package.json
+++ b/package.json
@@ -638,7 +638,7 @@
     "lint": "eslint .",
     "pretest": "npm run lint",
     "language:test": "vitest",
-    "dsc": "mkdir -p dist && npx tsx src/dsc",
+    "dsc": "bash -c 'mkdir -p dist' && npx tsx src/dsc",
     "package": "vsce package",
     "vscode:prepublish": "rm -rf dist && webpack --mode production && npm run dsc",
     "webpack": "webpack --mode development",


### PR DESCRIPTION
Makes an installed WSL a minimum requirement for Windows devs, but this seems like the cleanest solution that still works cross-platform