### PR TITLE
Change Result view ocntextual title to "DB2 for i"

### DIFF
--- a/package.json
+++ b/package.json
@@ -117,7 +117,7 @@
           "id": "vscode-db2i.resultset",
           "name": "Results",
           "when": "code-for-ibmi:connected == true",
-          "contextualTitle": "IBM i"
+          "contextualTitle": "DB2 for i"
         }
       ],
       "db2-explorer": [


### PR DESCRIPTION
Both IBM i Project Explorer and the DB2 for i extensions have the same contextual titles for their views, which is confusing if both are moved at the bottom:
![image](https://github.com/codefori/vscode-db2i/assets/11096890/d1aeb3df-dae6-47e8-ab30-184514fa9163)

This PR renames this extension's to `DB2 for i`:
![image](https://github.com/codefori/vscode-db2i/assets/11096890/e18ced93-32ca-4d57-b16c-c6009de6410d)
