### PR TITLE
Fixed schema objects ordering

### DIFF
--- a/src/database/schemas.ts
+++ b/src/database/schemas.ts
@@ -3,8 +3,8 @@ import { getInstance } from "../base";
 
 import { JobManager } from "../config";
 
-export type SQLType = "schemas"|"tables"|"views"|"aliases"|"constraints"|"functions"|"variables"|"indexes"|"procedures"|"sequences"|"packages"|"triggers"|"types";
-type PageData = {filter?: string, offset?: number, limit?: number};
+export type SQLType = "schemas" | "tables" | "views" | "aliases" | "constraints" | "functions" | "variables" | "indexes" | "procedures" | "sequences" | "packages" | "triggers" | "types";
+type PageData = { filter?: string, offset?: number, limit?: number };
 
 const typeMap = {
   'tables': [`T`, `P`],
@@ -33,100 +33,100 @@ export default class Schemas {
       switch (type) {
         case `schemas`:
           selects.push([
-            `select '${type}' as OBJ_TYPE, QSYS2.DELIMIT_NAME(SCHEMA_NAME) as NAME, SCHEMA_TEXT as TEXT, SYSTEM_SCHEMA_NAME as SYS_NAME, '' as SYS_SCHEMA, '' as SPECNAME, '' as BASE_SCHEMA, '' as BASE_OBJ`,
+            `select '${type}' as OBJ_TYPE, SCHEMA_NAME as NAME, SCHEMA_TEXT as TEXT, SYSTEM_SCHEMA_NAME as SYS_NAME, '' as SYS_SCHEMA, '' as SPECNAME, '' as BASE_SCHEMA, '' as BASE_OBJ`,
             `from QSYS2.SYSSCHEMAS`,
             details.filter ? `where UPPER(SCHEMA_NAME) = '${details.filter}' or UPPER(SYSTEM_SCHEMA_NAME) = '${details.filter}'` : ``,
           ].join(` `));
-            break;
-            
-      case `tables`:
-      case `views`:
-      case `aliases`:
-        selects.push([
-          `select '${type}' as OBJ_TYPE, TABLE_NAME as NAME, TABLE_TEXT as TEXT, SYSTEM_TABLE_NAME as SYS_NAME, SYSTEM_TABLE_SCHEMA as SYS_SCHEMA, '' as SPECNAME, BASE_TABLE_SCHEMA as BASE_SCHEMA, BASE_TABLE_NAME as BASE_OBJ`,
-          `from QSYS2.SYSTABLES`,
-          `where TABLE_SCHEMA = '${schema}' and TABLE_TYPE in (${typeMap[type].map(item => `'${item}'`).join(`, `)}) ${details.filter ? `and UPPER(TABLE_NAME) like '%${details.filter}%'`: ``}`,
-        ].join(` `));
-        break;
-  
-      case `constraints`:
-        selects.push([
-          `select '${type}' as OBJ_TYPE, CONSTRAINT_NAME as NAME, CONSTRAINT_TEXT as TEXT, SYSTEM_TABLE_NAME as SYS_NAME, SYSTEM_TABLE_SCHEMA as SYS_SCHEMA, '' as SPECNAME, TABLE_SCHEMA as BASE_SCHEMA, TABLE_NAME as BASE_OBJ`,
-          `from QSYS2.SYSCST`,
-          `where CONSTRAINT_SCHEMA = '${schema}' ${details.filter ? `and UPPER(CONSTRAINT_NAME) like '%${details.filter}%'`: ``}`,
-        ].join(` `));
-        break;
-  
-      case `functions`:
-        selects.push([
-          `select '${type}' as OBJ_TYPE, ROUTINE_NAME as NAME, coalesce(ROUTINE_TEXT, LONG_COMMENT) as TEXT, '' as SYS_NAME, '' as SYS_SCHEMA, SPECIFIC_NAME as SPECNAME, '' as BASE_SCHEMA, '' as BASE_OBJ`,
-          `from QSYS2.SYSFUNCS`,
-          `where ROUTINE_SCHEMA = '${schema}' ${details.filter ? `and UPPER(ROUTINE_NAME) like '%${details.filter}%'`: ``} and FUNCTION_ORIGIN in ('E','U')`,
-        ].join(` `));
-        break;
-  
-      case `variables`:
-        selects.push([
-          `select '${type}' as OBJ_TYPE, VARIABLE_NAME as NAME, VARIABLE_TEXT as TEXT, SYSTEM_VAR_NAME as SYS_NAME, SYSTEM_VAR_SCHEMA as SYS_SCHEMA, '' as SPECNAME, '' as BASE_SCHEMA, '' as BASE_OBJ`,
-          `from QSYS2.SYSVARIABLES`,
-          `where VARIABLE_SCHEMA = '${schema}' ${details.filter ? `and UPPER(VARIABLE_NAME) like '%${details.filter}%'`: ``}`,
-        ].join(` `));
-        break;
-  
-      case `indexes`:
-        selects.push([
-          `select '${type}' as OBJ_TYPE, INDEX_NAME as NAME, INDEX_TEXT as TEXT, SYSTEM_INDEX_NAME as SYS_NAME, SYSTEM_INDEX_SCHEMA as SYS_SCHEMA, '' as SPECNAME, TABLE_SCHEMA as BASE_SCHEMA, TABLE_NAME as BASE_OBJ`,
-          `from QSYS2.SYSINDEXES`,
-          `where INDEX_SCHEMA = '${schema}' ${details.filter ? `and UPPER(INDEX_NAME) like '%${details.filter}%'`: ``}`,
-        ].join(` `));
-        break;
-  
-      case `procedures`:
-        selects.push([
-          `select '${type}' as OBJ_TYPE, ROUTINE_NAME as NAME, ROUTINE_TEXT as TEXT, '' as SYS_NAME, '' as SYS_SCHEMA, SPECIFIC_NAME as SPECNAME, '' as BASE_SCHEMA, '' as BASE_OBJ`,
-          `from QSYS2.SYSPROCS`,
-          `where ROUTINE_SCHEMA = '${schema}' ${details.filter ? `and UPPER(ROUTINE_NAME) like '%${details.filter}%'`: ``}`,
-        ].join(` `));
-        break;
-  
-      case `sequences`:
-        selects.push([
-          `select '${type}' as OBJ_TYPE, SEQUENCE_NAME as NAME, SEQUENCE_TEXT as TEXT, SYSTEM_SEQ_NAME as SYS_NAME, SYSTEM_SEQ_SCHEMA as SYS_SCHEMA, '' as SPECNAME, '' as BASE_SCHEMA, '' as BASE_OBJ`,
-          `from QSYS2.SYSSEQUENCES`,
-          `where SEQUENCE_SCHEMA = '${schema}' ${details.filter ? `and UPPER(SEQUENCE_NAME) like '%${details.filter}%'`: ``}`,
-        ].join(` `));
-        break;
-  
-      // case `packages`:
-      //   selects.push([
-      //     `select '${type}' as OBJ_TYPE, PACKAGE_NAME as NAME, PACKAGE_TEXT as TEXT, PROGRAM_SCHEMA as BASE_SCHEMA, PROGRAM_NAME as BASE_OBJ, `,
-      //     `  '' as SYS_SCHEMA, '' as SYS_NAME, '' as SPECNAME`,
-      //     `from QSYS2.SQLPACKAGE`,
-      //     `where PACKAGE_SCHEMA = '${schema}' ${details.filter ? `and PACKAGE_NAME like '%${details.filter}%'`: ``}`,
-      //   ].join(` `));
-      //   break;
-  
-      case `triggers`:
-        selects.push([
-          `select '${type}' as OBJ_TYPE, TRIGGER_NAME as NAME, TRIGGER_TEXT as TEXT, '' as SYS_NAME, '' as SYS_SCHEMA, '' as SPECNAME, EVENT_OBJECT_SCHEMA as BASE_SCHEMA, EVENT_OBJECT_TABLE as BASE_OBJ`,
-          `from QSYS2.SYSTRIGGERS`,
-          `where TRIGGER_SCHEMA = '${schema}' ${details.filter ? `and UPPER(TRIGGER_NAME) like '%${details.filter}%'`: ``}`,
-        ].join(` `));
-        break;
-  
-      case `types`:
-        selects.push([
-          `select '${type}' as OBJ_TYPE, USER_DEFINED_TYPE_NAME as NAME, TYPE_TEXT as TEXT, SYSTEM_TYPE_NAME as SYS_NAME, SYSTEM_TYPE_SCHEMA as SYS_SCHEMA, '' as SPECNAME, '' as BASE_SCHEMA, '' as BASE_OBJ`,
-          `from QSYS2.SYSTYPES`,
-          `where USER_DEFINED_TYPE_SCHEMA = '${schema}' ${details.filter ? `and UPPER(USER_DEFINED_TYPE_NAME) like '%${details.filter}%'`: ``}`,
-        ].join(` `));
-        break;
+          break;
+
+        case `tables`:
+        case `views`:
+        case `aliases`:
+          selects.push([
+            `select '${type}' as OBJ_TYPE, TABLE_NAME as NAME, TABLE_TEXT as TEXT, SYSTEM_TABLE_NAME as SYS_NAME, SYSTEM_TABLE_SCHEMA as SYS_SCHEMA, '' as SPECNAME, BASE_TABLE_SCHEMA as BASE_SCHEMA, BASE_TABLE_NAME as BASE_OBJ`,
+            `from QSYS2.SYSTABLES`,
+            `where TABLE_SCHEMA = '${schema}' and TABLE_TYPE in (${typeMap[type].map(item => `'${item}'`).join(`, `)}) ${details.filter ? `and UPPER(TABLE_NAME) like '%${details.filter}%'` : ``}`,
+          ].join(` `));
+          break;
+
+        case `constraints`:
+          selects.push([
+            `select '${type}' as OBJ_TYPE, CONSTRAINT_NAME as NAME, CONSTRAINT_TEXT as TEXT, SYSTEM_TABLE_NAME as SYS_NAME, SYSTEM_TABLE_SCHEMA as SYS_SCHEMA, '' as SPECNAME, TABLE_SCHEMA as BASE_SCHEMA, TABLE_NAME as BASE_OBJ`,
+            `from QSYS2.SYSCST`,
+            `where CONSTRAINT_SCHEMA = '${schema}' ${details.filter ? `and UPPER(CONSTRAINT_NAME) like '%${details.filter}%'` : ``}`,
+          ].join(` `));
+          break;
+
+        case `functions`:
+          selects.push([
+            `select '${type}' as OBJ_TYPE, ROUTINE_NAME as NAME, coalesce(ROUTINE_TEXT, LONG_COMMENT) as TEXT, '' as SYS_NAME, '' as SYS_SCHEMA, SPECIFIC_NAME as SPECNAME, '' as BASE_SCHEMA, '' as BASE_OBJ`,
+            `from QSYS2.SYSFUNCS`,
+            `where ROUTINE_SCHEMA = '${schema}' ${details.filter ? `and UPPER(ROUTINE_NAME) like '%${details.filter}%'` : ``} and FUNCTION_ORIGIN in ('E','U')`,
+          ].join(` `));
+          break;
+
+        case `variables`:
+          selects.push([
+            `select '${type}' as OBJ_TYPE, VARIABLE_NAME as NAME, VARIABLE_TEXT as TEXT, SYSTEM_VAR_NAME as SYS_NAME, SYSTEM_VAR_SCHEMA as SYS_SCHEMA, '' as SPECNAME, '' as BASE_SCHEMA, '' as BASE_OBJ`,
+            `from QSYS2.SYSVARIABLES`,
+            `where VARIABLE_SCHEMA = '${schema}' ${details.filter ? `and UPPER(VARIABLE_NAME) like '%${details.filter}%'` : ``}`,
+          ].join(` `));
+          break;
+
+        case `indexes`:
+          selects.push([
+            `select '${type}' as OBJ_TYPE, INDEX_NAME as NAME, INDEX_TEXT as TEXT, SYSTEM_INDEX_NAME as SYS_NAME, SYSTEM_INDEX_SCHEMA as SYS_SCHEMA, '' as SPECNAME, TABLE_SCHEMA as BASE_SCHEMA, TABLE_NAME as BASE_OBJ`,
+            `from QSYS2.SYSINDEXES`,
+            `where INDEX_SCHEMA = '${schema}' ${details.filter ? `and UPPER(INDEX_NAME) like '%${details.filter}%'` : ``}`,
+          ].join(` `));
+          break;
+
+        case `procedures`:
+          selects.push([
+            `select '${type}' as OBJ_TYPE, ROUTINE_NAME as NAME, ROUTINE_TEXT as TEXT, '' as SYS_NAME, '' as SYS_SCHEMA, SPECIFIC_NAME as SPECNAME, '' as BASE_SCHEMA, '' as BASE_OBJ`,
+            `from QSYS2.SYSPROCS`,
+            `where ROUTINE_SCHEMA = '${schema}' ${details.filter ? `and UPPER(ROUTINE_NAME) like '%${details.filter}%'` : ``}`,
+          ].join(` `));
+          break;
+
+        case `sequences`:
+          selects.push([
+            `select '${type}' as OBJ_TYPE, SEQUENCE_NAME as NAME, SEQUENCE_TEXT as TEXT, SYSTEM_SEQ_NAME as SYS_NAME, SYSTEM_SEQ_SCHEMA as SYS_SCHEMA, '' as SPECNAME, '' as BASE_SCHEMA, '' as BASE_OBJ`,
+            `from QSYS2.SYSSEQUENCES`,
+            `where SEQUENCE_SCHEMA = '${schema}' ${details.filter ? `and UPPER(SEQUENCE_NAME) like '%${details.filter}%'` : ``}`,
+          ].join(` `));
+          break;
+
+        // case `packages`:
+        //   selects.push([
+        //     `select '${type}' as OBJ_TYPE, PACKAGE_NAME as NAME, PACKAGE_TEXT as TEXT, PROGRAM_SCHEMA as BASE_SCHEMA, PROGRAM_NAME as BASE_OBJ, `,
+        //     `  '' as SYS_SCHEMA, '' as SYS_NAME, '' as SPECNAME`,
+        //     `from QSYS2.SQLPACKAGE`,
+        //     `where PACKAGE_SCHEMA = '${schema}' ${details.filter ? `and PACKAGE_NAME like '%${details.filter}%'`: ``}`,
+        //   ].join(` `));
+        //   break;
+
+        case `triggers`:
+          selects.push([
+            `select '${type}' as OBJ_TYPE, TRIGGER_NAME as NAME, TRIGGER_TEXT as TEXT, '' as SYS_NAME, '' as SYS_SCHEMA, '' as SPECNAME, EVENT_OBJECT_SCHEMA as BASE_SCHEMA, EVENT_OBJECT_TABLE as BASE_OBJ`,
+            `from QSYS2.SYSTRIGGERS`,
+            `where TRIGGER_SCHEMA = '${schema}' ${details.filter ? `and UPPER(TRIGGER_NAME) like '%${details.filter}%'` : ``}`,
+          ].join(` `));
+          break;
+
+        case `types`:
+          selects.push([
+            `select '${type}' as OBJ_TYPE, USER_DEFINED_TYPE_NAME as NAME, TYPE_TEXT as TEXT, SYSTEM_TYPE_NAME as SYS_NAME, SYSTEM_TYPE_SCHEMA as SYS_SCHEMA, '' as SPECNAME, '' as BASE_SCHEMA, '' as BASE_OBJ`,
+            `from QSYS2.SYSTYPES`,
+            `where USER_DEFINED_TYPE_SCHEMA = '${schema}' ${details.filter ? `and UPPER(USER_DEFINED_TYPE_NAME) like '%${details.filter}%'` : ``}`,
+          ].join(` `));
+          break;
       }
     }
 
-    const query = `${selects.join(" UNION ALL ")} Order by NAME asc`;
+    const query = `${selects.join(" UNION ALL ")} Order by QSYS2.DELIMIT_NAME(NAME) asc`;
 
-    const objects : any[] = await JobManager.runSQL([
+    const objects: any[] = await JobManager.runSQL([
       query,
       `${details.limit ? `limit ${details.limit}` : ``} ${details.offset ? `offset ${details.offset}` : ``}`
     ].join(` `));
@@ -153,20 +153,20 @@ export default class Schemas {
    * @param object Not user input
    */
   static async generateSQL(schema: string, object: string, internalType: string): Promise<string> {
-    const lines = await JobManager.runSQL<{SRCDTA: string}>([
+    const lines = await JobManager.runSQL<{ SRCDTA: string }>([
       `CALL QSYS2.GENERATE_SQL(?, ?, ?, CREATE_OR_REPLACE_OPTION => '1', PRIVILEGES_OPTION => '0')`
-    ].join(` `), { parameters : [object, schema, internalType] });
+    ].join(` `), { parameters: [object, schema, internalType] });
 
     const generatedStatement = lines.map(line => line.SRCDTA).join(`\n`);
-    
+
     return generatedStatement;
   }
-  
-  static async deleteObject(schema: string, name:string, type: string): Promise<void> {
+
+  static async deleteObject(schema: string, name: string, type: string): Promise<void> {
     const query = `DROP ${(this.isRoutineType(type) ? 'SPECIFIC ' : '') + type} IF EXISTS ${schema}.${name}`;
     await getInstance().getContent().runSQL(query);
   }
-  
+
   static async renameObject(schema: string, oldName: string, newName: string, type: string): Promise<void> {
     const query = `RENAME ${type === 'view' ? 'table' : type} ${schema}.${oldName} TO ${newName}`;
     await getInstance().getContent().runSQL(query);

--- a/src/database/schemas.ts
+++ b/src/database/schemas.ts
@@ -1,7 +1,6 @@
 
 import { getInstance } from "../base";
 
-import Statement from "./statement";
 import { JobManager } from "../config";
 
 export type SQLType = "schemas"|"tables"|"views"|"aliases"|"constraints"|"functions"|"variables"|"indexes"|"procedures"|"sequences"|"packages"|"triggers"|"types";
@@ -20,8 +19,7 @@ export default class Schemas {
    * @param schema Not user input
    */
   static async getObjects(schema: string, types: SQLType[], details: PageData = {}): Promise<BasicSQLObject[]> {
-    let selects: string[] = [];
-    let query : string;
+    const selects: string[] = [];
 
     if (details.filter) {
       // This is so we can do a case insensitive filter
@@ -35,10 +33,9 @@ export default class Schemas {
       switch (type) {
         case `schemas`:
           selects.push([
-            `select '${type}' as OBJ_TYPE, SCHEMA_NAME as NAME, SCHEMA_TEXT as TEXT, SYSTEM_SCHEMA_NAME as SYS_NAME, '' as SYS_SCHEMA, '' as SPECNAME, '' as BASE_SCHEMA, '' as BASE_OBJ`,
+            `select '${type}' as OBJ_TYPE, QSYS2.DELIMIT_NAME(SCHEMA_NAME) as NAME, SCHEMA_TEXT as TEXT, SYSTEM_SCHEMA_NAME as SYS_NAME, '' as SYS_SCHEMA, '' as SPECNAME, '' as BASE_SCHEMA, '' as BASE_OBJ`,
             `from QSYS2.SYSSCHEMAS`,
             details.filter ? `where UPPER(SCHEMA_NAME) = '${details.filter}' or UPPER(SYSTEM_SCHEMA_NAME) = '${details.filter}'` : ``,
-            `order by QSYS2.DELIMIT_NAME(SCHEMA_NAME) asc`
           ].join(` `));
             break;
             
@@ -49,7 +46,6 @@ export default class Schemas {
           `select '${type}' as OBJ_TYPE, TABLE_NAME as NAME, TABLE_TEXT as TEXT, SYSTEM_TABLE_NAME as SYS_NAME, SYSTEM_TABLE_SCHEMA as SYS_SCHEMA, '' as SPECNAME, BASE_TABLE_SCHEMA as BASE_SCHEMA, BASE_TABLE_NAME as BASE_OBJ`,
           `from QSYS2.SYSTABLES`,
           `where TABLE_SCHEMA = '${schema}' and TABLE_TYPE in (${typeMap[type].map(item => `'${item}'`).join(`, `)}) ${details.filter ? `and UPPER(TABLE_NAME) like '%${details.filter}%'`: ``}`,
-          `order by TABLE_NAME asc`
         ].join(` `));
         break;
   
@@ -58,7 +54,6 @@ export default class Schemas {
           `select '${type}' as OBJ_TYPE, CONSTRAINT_NAME as NAME, CONSTRAINT_TEXT as TEXT, SYSTEM_TABLE_NAME as SYS_NAME, SYSTEM_TABLE_SCHEMA as SYS_SCHEMA, '' as SPECNAME, TABLE_SCHEMA as BASE_SCHEMA, TABLE_NAME as BASE_OBJ`,
           `from QSYS2.SYSCST`,
           `where CONSTRAINT_SCHEMA = '${schema}' ${details.filter ? `and UPPER(CONSTRAINT_NAME) like '%${details.filter}%'`: ``}`,
-          `order by CONSTRAINT_NAME asc`
         ].join(` `));
         break;
   
@@ -67,7 +62,6 @@ export default class Schemas {
           `select '${type}' as OBJ_TYPE, ROUTINE_NAME as NAME, coalesce(ROUTINE_TEXT, LONG_COMMENT) as TEXT, '' as SYS_NAME, '' as SYS_SCHEMA, SPECIFIC_NAME as SPECNAME, '' as BASE_SCHEMA, '' as BASE_OBJ`,
           `from QSYS2.SYSFUNCS`,
           `where ROUTINE_SCHEMA = '${schema}' ${details.filter ? `and UPPER(ROUTINE_NAME) like '%${details.filter}%'`: ``} and FUNCTION_ORIGIN in ('E','U')`,
-          `order by ROUTINE_NAME asc`
         ].join(` `));
         break;
   
@@ -76,7 +70,6 @@ export default class Schemas {
           `select '${type}' as OBJ_TYPE, VARIABLE_NAME as NAME, VARIABLE_TEXT as TEXT, SYSTEM_VAR_NAME as SYS_NAME, SYSTEM_VAR_SCHEMA as SYS_SCHEMA, '' as SPECNAME, '' as BASE_SCHEMA, '' as BASE_OBJ`,
           `from QSYS2.SYSVARIABLES`,
           `where VARIABLE_SCHEMA = '${schema}' ${details.filter ? `and UPPER(VARIABLE_NAME) like '%${details.filter}%'`: ``}`,
-          `order by VARIABLE_NAME asc`
         ].join(` `));
         break;
   
@@ -85,7 +78,6 @@ export default class Schemas {
           `select '${type}' as OBJ_TYPE, INDEX_NAME as NAME, INDEX_TEXT as TEXT, SYSTEM_INDEX_NAME as SYS_NAME, SYSTEM_INDEX_SCHEMA as SYS_SCHEMA, '' as SPECNAME, TABLE_SCHEMA as BASE_SCHEMA, TABLE_NAME as BASE_OBJ`,
           `from QSYS2.SYSINDEXES`,
           `where INDEX_SCHEMA = '${schema}' ${details.filter ? `and UPPER(INDEX_NAME) like '%${details.filter}%'`: ``}`,
-          `order by INDEX_NAME asc`
         ].join(` `));
         break;
   
@@ -94,7 +86,6 @@ export default class Schemas {
           `select '${type}' as OBJ_TYPE, ROUTINE_NAME as NAME, ROUTINE_TEXT as TEXT, '' as SYS_NAME, '' as SYS_SCHEMA, SPECIFIC_NAME as SPECNAME, '' as BASE_SCHEMA, '' as BASE_OBJ`,
           `from QSYS2.SYSPROCS`,
           `where ROUTINE_SCHEMA = '${schema}' ${details.filter ? `and UPPER(ROUTINE_NAME) like '%${details.filter}%'`: ``}`,
-          `order by ROUTINE_NAME asc`
         ].join(` `));
         break;
   
@@ -103,7 +94,6 @@ export default class Schemas {
           `select '${type}' as OBJ_TYPE, SEQUENCE_NAME as NAME, SEQUENCE_TEXT as TEXT, SYSTEM_SEQ_NAME as SYS_NAME, SYSTEM_SEQ_SCHEMA as SYS_SCHEMA, '' as SPECNAME, '' as BASE_SCHEMA, '' as BASE_OBJ`,
           `from QSYS2.SYSSEQUENCES`,
           `where SEQUENCE_SCHEMA = '${schema}' ${details.filter ? `and UPPER(SEQUENCE_NAME) like '%${details.filter}%'`: ``}`,
-          `order by SEQUENCE_NAME asc`
         ].join(` `));
         break;
   
@@ -113,7 +103,6 @@ export default class Schemas {
       //     `  '' as SYS_SCHEMA, '' as SYS_NAME, '' as SPECNAME`,
       //     `from QSYS2.SQLPACKAGE`,
       //     `where PACKAGE_SCHEMA = '${schema}' ${details.filter ? `and PACKAGE_NAME like '%${details.filter}%'`: ``}`,
-      //     `order by PACKAGE_NAME asc`
       //   ].join(` `));
       //   break;
   
@@ -122,7 +111,6 @@ export default class Schemas {
           `select '${type}' as OBJ_TYPE, TRIGGER_NAME as NAME, TRIGGER_TEXT as TEXT, '' as SYS_NAME, '' as SYS_SCHEMA, '' as SPECNAME, EVENT_OBJECT_SCHEMA as BASE_SCHEMA, EVENT_OBJECT_TABLE as BASE_OBJ`,
           `from QSYS2.SYSTRIGGERS`,
           `where TRIGGER_SCHEMA = '${schema}' ${details.filter ? `and UPPER(TRIGGER_NAME) like '%${details.filter}%'`: ``}`,
-          `order by TRIGGER_NAME asc`
         ].join(` `));
         break;
   
@@ -131,15 +119,14 @@ export default class Schemas {
           `select '${type}' as OBJ_TYPE, USER_DEFINED_TYPE_NAME as NAME, TYPE_TEXT as TEXT, SYSTEM_TYPE_NAME as SYS_NAME, SYSTEM_TYPE_SCHEMA as SYS_SCHEMA, '' as SPECNAME, '' as BASE_SCHEMA, '' as BASE_OBJ`,
           `from QSYS2.SYSTYPES`,
           `where USER_DEFINED_TYPE_SCHEMA = '${schema}' ${details.filter ? `and UPPER(USER_DEFINED_TYPE_NAME) like '%${details.filter}%'`: ``}`,
-          `order by USER_DEFINED_TYPE_NAME asc`
         ].join(` `));
         break;
       }
     }
 
-    query = selects.map(s => `select * from (${s})`).join(`\n UNION ALL \n`);
+    const query = `${selects.join(" UNION ALL ")} Order by NAME asc`;
 
-    let objects : any[] = await JobManager.runSQL([
+    const objects : any[] = await JobManager.runSQL([
       query,
       `${details.limit ? `limit ${details.limit}` : ``} ${details.offset ? `offset ${details.offset}` : ``}`
     ].join(` `));


### PR DESCRIPTION
Fixes https://github.com/codefori/vscode-db2i/issues/197

The query run when fetching the objects for the schemas browser was supposed to order the items alphabetically but the `Select * (...) Union All` applied to join the queries would prevent it.

This PR fixes this and restores the alphabetical order in the schemas browser.