### PR TITLE
Do not require focus when using certain prefixes

### DIFF
--- a/src/views/jobManager/statusBar.ts
+++ b/src/views/jobManager/statusBar.ts
@@ -5,7 +5,7 @@ import { getInstance } from "../../base";
 
 const item = window.createStatusBarItem(`sqlJob`, StatusBarAlignment.Left);
 
-export async function updateStatusBar(options: {newJob?: boolean} = {}) {
+export async function updateStatusBar(options: {newJob?: boolean, executing?: boolean} = {}) {
   const instance = getInstance();
   const connection = instance.getConnection();
 
@@ -16,6 +16,9 @@ export async function updateStatusBar(options: {newJob?: boolean} = {}) {
     let backgroundColour: ThemeColor|undefined = undefined;
     let toolTipItems = [];
 
+    if (options.executing) {
+      text = `$(sync~spin) Executing...`;
+    } else
     if (options.newJob) {
       text = `$(sync~spin) Spinning up job...`;
     } else

--- a/src/views/results/index.ts
+++ b/src/views/results/index.ts
@@ -239,13 +239,13 @@ async function runHandler(options?: StatementInfo) {
 
               const textDoc = await vscode.workspace.openTextDocument({ language: statementDetail.qualifier, content });
               await vscode.window.showTextDocument(textDoc);
-              resultSetProvider.setLoadingText(`Query executed with ${data.length} rows returned.`, false);
+              resultSetProvider.setLoadingText(`Statement executed with ${data.length} rows returned.`, false);
               break;
             }
 
           } else {
-            vscode.window.showInformationMessage(`Query executed with no data returned.`);
-            resultSetProvider.setLoadingText(`Query executed with no data returned.`);
+            vscode.window.showInformationMessage(`Statement executed with no data returned.`);
+            resultSetProvider.setLoadingText(`Statement executed with no data returned.`);
           }
         }
 

--- a/src/views/results/index.ts
+++ b/src/views/results/index.ts
@@ -15,6 +15,7 @@ import { DoveTreeDecorationProvider } from "./explain/doveTreeDecorationProvider
 import { ResultSetPanelProvider } from "./resultSetPanelProvider";
 import { ExplainType } from "../../connection/sqlJob";
 import { generateSqlForAdvisedIndexes } from "./explain/advice";
+import { updateStatusBar } from "../jobManager/statusBar";
 
 export type StatementQualifier = "statement" | "explain" | "onlyexplain" | "json" | "csv" | "cl" | "sql";
 
@@ -153,44 +154,44 @@ async function runHandler(options?: StatementInfo) {
     if (statementDetail.content.trim().length > 0) {
       try {
         if (statementDetail.qualifier === `cl`) {
-          resultSetProvider.setScrolling(statementDetail.content, true);
+          resultSetProvider.setScrolling(statementDetail.content, true); // Never errors
         } else if (statementDetail.qualifier === `statement`) {
           // If it's a basic statement, we can let it scroll!
-          resultSetProvider.setScrolling(statementDetail.content);
+          resultSetProvider.setScrolling(statementDetail.content); // Never errors
 
         } else if ([`explain`, `onlyexplain`].includes(statementDetail.qualifier)) {
+          // If it's an explain, we need to 
           const selectedJob = JobManager.getSelection();
           if (selectedJob) {
-            try {
-              const onlyExplain = statementDetail.qualifier === `onlyexplain`;
+            const onlyExplain = statementDetail.qualifier === `onlyexplain`;
 
-              resultSetProvider.setLoadingText(onlyExplain ? `Explaining without running...` : `Explaining...`);
-              const explainType: ExplainType = onlyExplain ? ExplainType.DoNotRun : ExplainType.Run;
+            resultSetProvider.setLoadingText(onlyExplain ? `Explaining without running...` : `Explaining...`);
+            const explainType: ExplainType = onlyExplain ? ExplainType.DoNotRun : ExplainType.Run;
 
-              const explained = await selectedJob.job.explain(statementDetail.content, explainType);
+            // Also enable to cancel button here.
+            const explained = await selectedJob.job.explain(statementDetail.content, explainType); // Can throw
 
-              if (onlyExplain) {
-                resultSetProvider.setLoadingText(`Explained.`);
-              } else {
-                resultSetProvider.setScrolling(statementDetail.content, false, explained.id);
-              }
-
-              explainTree = new ExplainTree(explained.vedata);
-              const topLevel = explainTree.get();
-              const rootNode = doveResultsView.setRootNode(topLevel);
-              doveNodeView.setNode(rootNode.explainNode);
-              doveTreeDecorationProvider.updateTreeItems(rootNode);
-            } catch (e) {
-              resultSetProvider.setError(e.message);
+            if (onlyExplain) {
+              resultSetProvider.setLoadingText(`Explained.`);
+            } else {
+              resultSetProvider.setScrolling(statementDetail.content, false, explained.id); // Never errors
             }
+
+            explainTree = new ExplainTree(explained.vedata);
+            const topLevel = explainTree.get();
+            const rootNode = doveResultsView.setRootNode(topLevel);
+            doveNodeView.setNode(rootNode.explainNode);
+            doveTreeDecorationProvider.updateTreeItems(rootNode);
           } else {
             vscode.window.showInformationMessage(`No job currently selected.`);
           }
         } else {
           // Otherwise... it's a bit complicated.
-          resultSetProvider.setLoadingText(`Executing SQL statement...`);
+          resultSetProvider.setLoadingText(`Executing SQL statement...`, false);
 
-          const data = await JobManager.runSQL(statementDetail.content, undefined);
+          updateStatusBar({ executing: true });
+          // Also enable to cancel button here.
+          const data = await JobManager.runSQL(statementDetail.content, undefined); // Can throw
 
           if (data.length > 0) {
             switch (statementDetail.qualifier) {
@@ -238,7 +239,7 @@ async function runHandler(options?: StatementInfo) {
 
               const textDoc = await vscode.workspace.openTextDocument({ language: statementDetail.qualifier, content });
               await vscode.window.showTextDocument(textDoc);
-              resultSetProvider.setLoadingText(`Query executed with ${data.length} rows returned.`);
+              resultSetProvider.setLoadingText(`Query executed with ${data.length} rows returned.`, false);
               break;
             }
 
@@ -247,9 +248,11 @@ async function runHandler(options?: StatementInfo) {
             resultSetProvider.setLoadingText(`Query executed with no data returned.`);
           }
         }
+
         if ((statementDetail.qualifier === `statement` || statementDetail.qualifier === `explain`) && statementDetail.history !== false) {
           vscode.commands.executeCommand(`vscode-db2i.queryHistory.prepend`, statementDetail.content);
         }
+
       } catch (e) {
         let errorText;
         if (typeof e === `string`) {
@@ -258,12 +261,14 @@ async function runHandler(options?: StatementInfo) {
           errorText = e.message || `Error running SQL statement.`;
         }
 
-        if (statementDetail.qualifier === `statement` && statementDetail.history !== false) {
+        if ([`statement`, `explain`, `onlyexplain`].includes(statementDetail.qualifier) && statementDetail.history !== false) {
           resultSetProvider.setError(errorText);
         } else {
           vscode.window.showErrorMessage(errorText);
         }
       }
+
+      updateStatusBar();
     }
   }
 }

--- a/src/views/results/resultSetPanelProvider.ts
+++ b/src/views/results/resultSetPanelProvider.ts
@@ -83,8 +83,10 @@ export class ResultSetPanelProvider {
     }
   }
 
-  async setLoadingText(content) {
-    await this.focus();
+  async setLoadingText(content: string, focus = true) {
+    if (focus) {
+      await this.focus();
+    }
 
     if (!this.loadingState) {
       this._view.webview.html = html.getLoadingHTML();


### PR DESCRIPTION
Improved state when running statements that generate raw documents.

* No longer focus on results view automatically
* Improve state on the database status bar item when executing to generate documents