### PR TITLE
Use `with` statement for filtering to work

### DIFF
--- a/src/database/schemas.ts
+++ b/src/database/schemas.ts
@@ -124,7 +124,7 @@ export default class Schemas {
       }
     }
 
-    const query = `${selects.join(" UNION ALL ")} Order by QSYS2.DELIMIT_NAME(NAME) asc`;
+    const query = `with results as (${selects.join(" UNION ALL ")}) select * from results Order by QSYS2.DELIMIT_NAME(NAME) asc`;
 
     const objects: any[] = await JobManager.runSQL([
       query,

--- a/src/testing/database.ts
+++ b/src/testing/database.ts
@@ -1,7 +1,7 @@
 import assert from "assert";
 import { TestSuite } from ".";
 import { JobManager } from "../config";
-import Database from "../database/schemas";
+import Database, { AllSQLTypes } from "../database/schemas";
 import Statement from "../database/statement";
 import Callable from "../database/callable";
 import { getInstance } from "../base";
@@ -93,6 +93,12 @@ export const DatabaseSuite: TestSuite = {
 
     {name: `Get tables, system name`, test: async () => {
       const objects = await Database.getObjects(systemLibrary, [`tables`]);
+
+      assert.notStrictEqual(objects.length, 0);
+    }},
+
+    {name: `Schema filter test`, test: async () => {
+      const objects = await Database.getObjects(systemLibrary, AllSQLTypes, {filter: `emp`});
 
       assert.notStrictEqual(objects.length, 0);
     }},


### PR DESCRIPTION
* Wrap `select` statements for multiple object types in a `with` clause to enable schema filtering to work again