### PR TITLE
Always turn cancel button off when a query is done

### DIFF
--- a/src/views/results/resultSetPanelProvider.ts
+++ b/src/views/results/resultSetPanelProvider.ts
@@ -1,10 +1,10 @@
-import { WebviewView, WebviewViewResolveContext, CancellationToken, commands } from "vscode";
+import { CancellationToken, WebviewView, WebviewViewResolveContext, commands } from "vscode";
 
-import { Query, QueryState } from "../../connection/query";
-import * as html from "./html";
-import { updateStatusBar } from "../jobManager/statusBar";
-import { JobManager } from "../../config";
 import { setCancelButtonVisibility } from ".";
+import { JobManager } from "../../config";
+import { Query, QueryState } from "../../connection/query";
+import { updateStatusBar } from "../jobManager/statusBar";
+import * as html from "./html";
 
 export class ResultSetPanelProvider {
   _view: WebviewView;
@@ -38,9 +38,7 @@ export class ResultSetPanelProvider {
             queryObject = query;
           }
 
-          let queryResults = queryObject.getState() == QueryState.RUN_MORE_DATA_AVAILABLE ? await queryObject.fetchMore() : await queryObject.run();
-
-          setCancelButtonVisibility(false);
+          let queryResults = queryObject.getState() == QueryState.RUN_MORE_DATA_AVAILABLE ? await queryObject.fetchMore() : await queryObject.run();          
 
           data = queryResults.data;
           this._view.webview.postMessage({
@@ -60,6 +58,9 @@ export class ResultSetPanelProvider {
             queryId: ``,
             isDone: true
           });
+        }
+        finally{
+          setCancelButtonVisibility(false);
         }
 
         updateStatusBar();

--- a/src/views/results/resultSetPanelProvider.ts
+++ b/src/views/results/resultSetPanelProvider.ts
@@ -38,7 +38,7 @@ export class ResultSetPanelProvider {
             queryObject = query;
           }
 
-          let queryResults = queryObject.getState() == QueryState.RUN_MORE_DATA_AVAILABLE ? await queryObject.fetchMore() : await queryObject.run();          
+          let queryResults = queryObject.getState() == QueryState.RUN_MORE_DATA_AVAILABLE ? await queryObject.fetchMore() : await queryObject.run();
 
           data = queryResults.data;
           this._view.webview.postMessage({
@@ -59,10 +59,8 @@ export class ResultSetPanelProvider {
             isDone: true
           });
         }
-        finally{
-          setCancelButtonVisibility(false);
-        }
 
+        setCancelButtonVisibility(false);
         updateStatusBar();
       }
     });


### PR DESCRIPTION
The Cancel button in the editor title was not turned off when a query ended in error.
This PR turns the Cancel button off regardless of the query's end status.

# How to test
- Run a query that crashes: `select * from nothing`
- The cancel button must be turned off
- Run a query that is successful: 'select * from qsys2.netstat_info'
- The cancel button must be turned off as well