### PR TITLE
Fix for when group exists without end block

### DIFF
--- a/src/language/sql/document.ts
+++ b/src/language/sql/document.ts
@@ -106,7 +106,9 @@ export default class Document {
             groups.push({
               range: { start: currentGroup[0].range.start, end: currentGroup[currentGroup.length-1].range.end },
               statements: currentGroup
-            })
+            });
+
+            currentGroup = [];
           }
         } else
         if (statement.isBlockOpener()) {
@@ -128,6 +130,13 @@ export default class Document {
             });
           }
         }
+    }
+
+    if (currentGroup.length > 0) {
+      groups.push({
+        range: { start: currentGroup[0].range.start, end: currentGroup[currentGroup.length-1].range.end },
+        statements: currentGroup
+      });
     }
 
     return groups;


### PR DESCRIPTION
Even though this statement was invalid, it was not runnable because it was not being registered as valid group.

```
create or replace procedure coolstuff.selfrocks()
begin
select count(*) into novar from mylib.nofile
end;
```