### PR TITLE
Fix issue where reconnected job had a bad status

### DIFF
--- a/src/connection/sqlJob.ts
+++ b/src/connection/sqlJob.ts
@@ -181,19 +181,19 @@ export class SQLJob {
 
     const connectResult: ConnectionResult = JSON.parse(result);
 
-    if (connectResult.success !== true) {
+    if (connectResult.success === true) {
+      this.status = JobStatus.Ready;
+    } else {
       this.dispose();
       this.status = JobStatus.NotStarted;
       throw new Error(connectResult.error || `Failed to connect to server.`);
     }
 
-    if (this.status === JobStatus.Ended) {
+    if (this.status !== JobStatus.Ready) {
       throw new Error(`Failed to connect properly.`);
     }
 
     this.id = connectResult.job;
-    this.status = JobStatus.Ready;
-
     this.isTracingChannelData = false;
 
     return connectResult;

--- a/src/connection/sqlJob.ts
+++ b/src/connection/sqlJob.ts
@@ -189,10 +189,6 @@ export class SQLJob {
       throw new Error(connectResult.error || `Failed to connect to server.`);
     }
 
-    if (this.status !== JobStatus.Ready) {
-      throw new Error(`Failed to connect properly.`);
-    }
-
     this.id = connectResult.job;
     this.isTracingChannelData = false;
 


### PR DESCRIPTION
Previously, when editing job settings, the new job would be successfully created. But, it was still in `ended` state. This solves that problem so job settings can be changed correctly.