### PR TITLE
List query history by date

### DIFF
--- a/package.json
+++ b/package.json
@@ -197,7 +197,7 @@
         },
         {
           "id": "queryHistory",
-          "name": "Query History",
+          "name": "Statement History",
           "visibility": "visible",
           "when": "code-for-ibmi:connected == true"
         },
@@ -222,7 +222,7 @@
     "viewsWelcome": [
       {
         "view": "queryHistory",
-        "contents": "Query history will appear here."
+        "contents": "Statement history will appear here."
       },
       {
         "view": "jobManager",
@@ -367,13 +367,13 @@
       },
       {
         "command": "vscode-db2i.queryHistory.remove",
-        "title": "Remove query from history",
+        "title": "Remove statement from history",
         "category": "Db2 for i",
         "icon": "$(trash)"
       },
       {
         "command": "vscode-db2i.queryHistory.clear",
-        "title": "Clear query history",
+        "title": "Clear statement history",
         "category": "Db2 for i",
         "icon": "$(trash)"
       },

--- a/src/config.ts
+++ b/src/config.ts
@@ -23,6 +23,8 @@ export async function onConnectOrServerInstall(): Promise<boolean> {
 
   Config.setConnectionName(instance.getConnection().currentConnectionName);
 
+  await Config.fixPastQueries();
+
   await ServerComponent.initialise().then(installed => {
     if (installed) {
       JobManagerView.setVisible(true);

--- a/src/views/queryHistoryView.ts
+++ b/src/views/queryHistoryView.ts
@@ -95,36 +95,37 @@ export class queryHistory implements TreeDataProvider<any> {
         const weekAgo = now - week;
         const monthAgo = now - month;
 
-        let dayQueries: PastQueryNode[] = [];
-        let weekQueries: PastQueryNode[] = [];
-        let monthQueries: PastQueryNode[] = [];
-        let laterQueries: PastQueryNode[] = [];
+        let pastDayQueries: PastQueryNode[] = [];
+        let pastWeekQueries: PastQueryNode[] = [];
+        let pastMonthQueries: PastQueryNode[] = [];
+        let olderQueries: PastQueryNode[] = [];
 
         currentList.forEach(queryItem => {
-          if (queryItem.unix > monthAgo) {
-             laterQueries.push(new PastQueryNode(queryItem.query));
-          } else if (queryItem.unix > weekAgo) {
-            monthQueries.push(new PastQueryNode(queryItem.query));
-         } else if (queryItem.unix > dayAgo) {
-            weekQueries.push(new PastQueryNode(queryItem.query));
+          // The smaller the unix value, the older it is
+          if (queryItem.unix < monthAgo) {
+             olderQueries.push(new PastQueryNode(queryItem.query));
+          } else if (queryItem.unix < weekAgo) {
+            pastMonthQueries.push(new PastQueryNode(queryItem.query));
+         } else if (queryItem.unix < dayAgo) {
+            pastWeekQueries.push(new PastQueryNode(queryItem.query));
          } else {
-            dayQueries.push(new PastQueryNode(queryItem.query));
+            pastDayQueries.push(new PastQueryNode(queryItem.query));
          }
         });
 
         let nodes: TimePeriodNode[] = [];
 
-        if (dayQueries.length > 0) {
-          nodes.push(new TimePeriodNode(`Past day`, dayQueries, true));
+        if (pastDayQueries.length > 0) {
+          nodes.push(new TimePeriodNode(`Past day`, pastDayQueries, true));
         }
-        if (weekQueries.length > 0) {
-          nodes.push(new TimePeriodNode(`Past week`, weekQueries));
+        if (pastWeekQueries.length > 0) {
+          nodes.push(new TimePeriodNode(`Past week`, pastWeekQueries));
         }
-        if (monthQueries.length > 0) {
-          nodes.push(new TimePeriodNode(`Past month`, monthQueries));
+        if (pastMonthQueries.length > 0) {
+          nodes.push(new TimePeriodNode(`Past month`, pastMonthQueries));
         }
-        if (laterQueries.length > 0) {
-          nodes.push(new TimePeriodNode(`Older`, laterQueries));
+        if (olderQueries.length > 0) {
+          nodes.push(new TimePeriodNode(`Older`, olderQueries));
         }
 
         return nodes;

--- a/src/views/queryHistoryView.ts
+++ b/src/views/queryHistoryView.ts
@@ -124,7 +124,7 @@ export class queryHistory implements TreeDataProvider<any> {
           nodes.push(new TimePeriodNode(`Past month`, monthQueries));
         }
         if (laterQueries.length > 0) {
-          nodes.push(new TimePeriodNode(`Later`, laterQueries));
+          nodes.push(new TimePeriodNode(`Older`, laterQueries));
         }
 
         return nodes;

--- a/src/views/queryHistoryView.ts
+++ b/src/views/queryHistoryView.ts
@@ -101,15 +101,15 @@ export class queryHistory implements TreeDataProvider<any> {
         let laterQueries: PastQueryNode[] = [];
 
         currentList.forEach(queryItem => {
-          if (queryItem.unix < dayAgo) {
-            dayQueries.push(new PastQueryNode(queryItem.query));
-          } else if (queryItem.unix < weekAgo) {
-            weekQueries.push(new PastQueryNode(queryItem.query));
-          } else if (queryItem.unix < monthAgo) {
+          if (queryItem.unix > monthAgo) {
+             laterQueries.push(new PastQueryNode(queryItem.query));
+          } else if (queryItem.unix > weekAgo) {
             monthQueries.push(new PastQueryNode(queryItem.query));
-          } else {
-            laterQueries.push(new PastQueryNode(queryItem.query));
-          }
+         } else if (queryItem.unix > dayAgo) {
+            weekQueries.push(new PastQueryNode(queryItem.query));
+         } else {
+            dayQueries.push(new PastQueryNode(queryItem.query));
+         }
         });
 
         let nodes: TimePeriodNode[] = [];


### PR DESCRIPTION
* Change how we store history internally (no longer a list of strings)
* Group statements by simple period (past day, past week, past month, later)
* All but first are collapsed by default

warning: if you test this PR, it will break your existing query history