### PR TITLE
Add SelfIleStackFrame and InitialStackData interfaces for SELF

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -31,6 +31,7 @@ export async function onConnectOrServerInstall(): Promise<boolean> {
   const instance = getInstance();
 
   Config.setConnectionName(instance.getConnection().currentConnectionName);
+  determineFeatures();
 
   await ServerComponent.initialise().then(installed => {
     if (installed) {
@@ -74,8 +75,6 @@ export async function onConnectOrServerInstall(): Promise<boolean> {
 
 export function setupConfig(context: ExtensionContext) {
   Config = new ConnectionStorage(context);
-
-  getInstance().onEvent(`connected`, onConnectOrServerInstall);
 
   getInstance().onEvent(`disconnected`, async () => {
     JobManagerView.setVisible(false);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -7,7 +7,7 @@ import * as JSONServices from "./language/json";
 import * as resultsProvider from "./views/results";
 
 import { getInstance, loadBase } from "./base";
-import { JobManager, determineFeatures, fetchSystemInfo, setupConfig, turnOffAllFeatures } from "./config";
+import { JobManager, fetchSystemInfo, onConnectOrServerInstall, setupConfig, turnOffAllFeatures } from "./config";
 import { queryHistory } from "./views/queryHistoryView";
 import { ExampleBrowser } from "./views/examples/exampleBrowser";
 import { languageInit } from "./language";
@@ -83,8 +83,8 @@ export function activate(context: vscode.ExtensionContext): Db2i {
   instance.onEvent(`connected`, () => {
     // We need to fetch the system info
     fetchSystemInfo().then(() => {
-      determineFeatures();
       // Refresh the examples when we have it, so we only display certain examples
+      onConnectOrServerInstall();
       exampleBrowser.refresh();
       selfCodesView.setRefreshEnabled(Configuration.get(`autoRefreshSelfCodesView`) || false)
     })

--- a/src/views/examples/exampleBrowser.ts
+++ b/src/views/examples/exampleBrowser.ts
@@ -4,7 +4,7 @@ import { getInstance } from "../../base";
 import { OSData, fetchSystemInfo } from "../../config";
 import { getServiceInfo } from "../../database/serviceInfo";
 
-const openExampleCommand = `vscode-db2i.examples.open`;
+export const openExampleCommand = `vscode-db2i.examples.open`;
 
 export class ExampleBrowser implements TreeDataProvider<any> {
   private _onDidChangeTreeData: EventEmitter<TreeItem | undefined | null | void> = new EventEmitter<TreeItem | undefined | null | void>();

--- a/src/views/jobManager/jobManagerView.ts
+++ b/src/views/jobManager/jobManagerView.ts
@@ -175,7 +175,7 @@ export class JobManagerView implements TreeDataProvider<any> {
             quickPick.onDidChangeSelection(async () => {
               const selections = quickPick.selectedItems;
               // SET SYSIBMADM.SELFCODES = SYSIBMADM.VALIDATE_SELF('-514, -204, -501, +30, -199');
-              if (selections && selections[0].label !== currentSelfCodes) {
+              if (selections && selections[0] && selections[0].label !== currentSelfCodes) {
                 const code = selections[0].label as SelfValue;
                 try {
                   await selected.job.setSelfState(code);

--- a/src/views/jobManager/selfCodes/nodes.ts
+++ b/src/views/jobManager/selfCodes/nodes.ts
@@ -1,3 +1,19 @@
+
+export interface SelfIleStackFrame {
+  ORD: number;
+  TYPE: string;
+  LIB: string;
+  PGM: string;
+  MODULE: string;
+  PROC: string;
+  STMT: string;
+  ACTGRP: string;
+}
+
+export interface InitialStackData {
+  initial_stack: SelfIleStackFrame[];
+}
+
 export interface SelfCodeNode {
   JOB_NAME: string,
   USER_NAME: string;
@@ -9,6 +25,14 @@ export interface SelfCodeNode {
   STMTTEXT: string;
   MESSAGE_TEXT: string;
   MESSAGE_SECOND_LEVEL_TEXT: string;
+
+  PROGRAM_LIBRARY: string;
+  PROGRAM_NAME: string;
+  PROGRAM_TYPE: "*PGM"|"*SRVPGM";
+  MODULE_NAME: string;
+  CLIENT_APPLNAME: string
+  CLIENT_PROGRAMID: string;
+  INITIAL_STACK: InitialStackData;
 }
 
 export type SelfValue = "*ALL" | "*ERROR" | "*WARNING" | "*NONE";

--- a/src/views/jobManager/selfCodes/selfCodesResultsView.ts
+++ b/src/views/jobManager/selfCodes/selfCodesResultsView.ts
@@ -184,15 +184,24 @@ export class SelfCodeTreeItem extends TreeItem {
     this.contextValue = `selfCodeNode`;
   }
 
-  getChilden(): SelfErrorNodeItem[] {
-    return [
+  getChilden(): TreeItem[] {
+    const validStack = this.error.INITIAL_STACK.initial_stack
+      .sort((a, b) => a.ORD - b.ORD) // Ord, low to high
+      .filter((stack) => stack.LIB !== `QSYS`);
+
+    const items = [
       new SelfErrorStatementItem(this.error.STMTTEXT),
       new SelfErrorNodeItem(`Job`, this.error.JOB_NAME),
       new SelfErrorNodeItem(`Client Name`, this.error.CLIENT_APPLNAME),
       new SelfErrorNodeItem(`Client Program`, this.error.CLIENT_PROGRAMID),
       new SelfErrorNodeItem(`Object`, `${this.error.PROGRAM_LIBRARY}/${this.error.PROGRAM_NAME} (${this.error.PROGRAM_TYPE}, ${this.error.MODULE_NAME})`),
-      new SelfErrorStackItem(this.error.INITIAL_STACK.initial_stack)
     ]
+
+    if (validStack.length > 0) {
+      items.push(new SelfErrorStackItem(validStack));
+    }
+
+    return items;
   }
 }
 

--- a/src/views/jobManager/selfCodes/selfCodesResultsView.ts
+++ b/src/views/jobManager/selfCodes/selfCodesResultsView.ts
@@ -11,6 +11,8 @@ import {
 } from "vscode";
 import { JobManager } from "../../../config";
 import { SelfCodeNode, SelfIleStackFrame } from "./nodes";
+import { openExampleCommand } from "../../examples/exampleBrowser";
+import { SQLExample } from "../../examples";
 
 type ChangeTreeDataEventType = SelfCodeTreeItem | undefined | null | void;
 
@@ -184,12 +186,36 @@ export class SelfCodeTreeItem extends TreeItem {
 
   getChilden(): SelfErrorNodeItem[] {
     return [
+      new SelfErrorStatementItem(this.error.STMTTEXT),
       new SelfErrorNodeItem(`Job`, this.error.JOB_NAME),
       new SelfErrorNodeItem(`Client Name`, this.error.CLIENT_APPLNAME),
       new SelfErrorNodeItem(`Client Program`, this.error.CLIENT_PROGRAMID),
       new SelfErrorNodeItem(`Object`, `${this.error.PROGRAM_LIBRARY}/${this.error.PROGRAM_NAME} (${this.error.PROGRAM_TYPE}, ${this.error.MODULE_NAME})`),
       new SelfErrorStackItem(this.error.INITIAL_STACK.initial_stack)
     ]
+  }
+}
+
+class SelfErrorStatementItem extends TreeItem {
+  constructor(statement: string) {
+    super(`Statement`, vscode.TreeItemCollapsibleState.None);
+    this.iconPath = new vscode.ThemeIcon(`database`);
+    this.description = statement;
+
+    const hoverable = new vscode.MarkdownString();
+    hoverable.appendCodeblock(statement, `sql`);
+    this.tooltip = hoverable;
+
+    const example: SQLExample = {
+      name: `Statement`,
+      content: [statement]
+    }
+    
+    this.command = {
+      command: openExampleCommand,
+      title: `Open example`,
+      arguments: [example]
+    };
   }
 }
 


### PR DESCRIPTION
Adds the following functionality:

* SELF errors can now be expanded to show more information we didn't show before, including client name, program and object
* We also include the stack trace for the self error in a nicely formatted view
* Fixes bug where first job after connecting to the server was not setting the SELF code