### PR TITLE
Fix resultSet view not grabing focus after reconnection

### DIFF
--- a/src/views/results/resultSetPanelProvider.ts
+++ b/src/views/results/resultSetPanelProvider.ts
@@ -1,4 +1,4 @@
-import { CancellationToken, WebviewView, WebviewViewResolveContext, commands } from "vscode";
+import { CancellationToken, WebviewView, WebviewViewProvider, WebviewViewResolveContext, commands } from "vscode";
 
 import { setCancelButtonVisibility } from ".";
 import { JobManager } from "../../config";
@@ -6,7 +6,7 @@ import { Query, QueryState } from "../../connection/query";
 import { updateStatusBar } from "../jobManager/statusBar";
 import * as html from "./html";
 
-export class ResultSetPanelProvider {
+export class ResultSetPanelProvider implements WebviewViewProvider {
   _view: WebviewView;
   loadingState: boolean;
   constructor() {
@@ -16,6 +16,7 @@ export class ResultSetPanelProvider {
 
   resolveWebviewView(webviewView: WebviewView, context: WebviewViewResolveContext, _token: CancellationToken) {
     this._view = webviewView;
+    this._view.onDidDispose(() => this._view = undefined);
 
     webviewView.webview.options = {
       // Allow scripts in the webview
@@ -73,6 +74,7 @@ export class ResultSetPanelProvider {
       await delay(100);
       currentLoop += 1;
     }
+    this._view.show(true);
   }
 
   async focus() {
@@ -82,8 +84,6 @@ export class ResultSetPanelProvider {
       // 1. calls resolveWebviewView
       // 2. sets this._view
       await commands.executeCommand(`vscode-db2i.resultset.focus`);
-    } else {
-      this._view.show(true);
     }
   }
 


### PR DESCRIPTION
This PR fixes an issue causing the ResultSet view to not grab the focus when running a statement after disconnecting and reconnecting to an IBM i.

This was caused by the `ResultSetPanelProvider` not keeping track of the `disposed` status of the webview, preventing the `ensureActivation` from working properly.

By resetting the reference to the resolved webview once it's disposed, the `ensureActivation` method can work as expected after reconnecting to a system.

## How to test
1. Connect to an IBM i
2. Run a statement
3. The Result Set webview must grab the focus and display the results
4. Disconnect
5. Connect again
6. Run a statement
7. The Result Set webview must grab the focus and display the results again

Without this PR, step `7.` doesn't happen and the user must manually reveal the result set webview.