### PR TITLE
Fix CL statements over multiple lines

### DIFF
--- a/src/views/results/index.ts
+++ b/src/views/results/index.ts
@@ -352,6 +352,11 @@ export function parseStatement(editor?: vscode.TextEditor, existingInfo?: Statem
         }
       });
     }
+
+    if (statementInfo.qualifier === `cl`) {
+      const eol = document.eol === vscode.EndOfLine.CRLF ? `\r\n` : `\n`;
+      statementInfo.content = statementInfo.content.split(eol).map(line => line.trim()).join(` `);
+    }
   }
 
   statementInfo.statement = statementInfo.group.statements[0];


### PR DESCRIPTION
Fixes a bug where CLs wouldn't run when the statement contained new line characters.

![image](https://github.com/codefori/vscode-db2i/assets/3708366/19611eb3-dd04-46aa-9fd8-4831d63a9649)
