### PR TITLE
Add footer to results table so status is always visible

### DIFF
--- a/src/views/html.ts
+++ b/src/views/html.ts
@@ -20,6 +20,13 @@ export function getHeader(options: {withCollapsed?: boolean} = {}): string {
       top: 0;           /* Don't forget this, required for the stickiness */
     }
 
+    tfoot tr {
+      background-color: rgb(128, 128, 128); /* same as var(--vscode-panelSectionHeader-background) but without transparancy */
+      text-align: left;
+      position: sticky; /* Lock the footer row to the bottom so it's always visible as rows are scrolled */
+      bottom: 0;        /* Don't forget this, required for the stickiness */
+    }
+
     #resultset th,
     #resultset td {
       padding: 5px 15px;

--- a/src/views/html.ts
+++ b/src/views/html.ts
@@ -21,7 +21,7 @@ export function getHeader(options: {withCollapsed?: boolean} = {}): string {
     }
 
     tfoot tr {
-      background-color: rgb(128, 128, 128); /* same as var(--vscode-panelSectionHeader-background) but without transparancy */
+      background-color: var(--vscode-multiDiffEditor-headerBackground);
       text-align: left;
       position: sticky; /* Lock the footer row to the bottom so it's always visible as rows are scrolled */
       bottom: 0;        /* Don't forget this, required for the stickiness */

--- a/src/views/results/html.ts
+++ b/src/views/results/html.ts
@@ -99,7 +99,7 @@ export function generateScroller(basicSelect: string, isCL: boolean): string {
                   if (data.rows === undefined && totalRows === 0) {
                     document.getElementById(messageSpanId).innerText = 'Statement executed with no result set returned. Rows affected: ' + data.update_count;
                   } else {
-                    document.getElementById(statusId).innerText = noMoreRows ? ('Loaded ' + totalRows + '. End of data') : ('Loaded ' + totalRows + '. More available...');
+                    document.getElementById(statusId).innerText = noMoreRows ? ('Loaded ' + totalRows + '. End of data') : ('Loaded ' + totalRows + '. More available.');
                     document.getElementById(messageSpanId).style.visibility = "hidden";
                   }
                   break;


### PR DESCRIPTION
The results table view features a span that is updated with status, eg. statement running, row count...
The problem is that with a larger result set, the span remains out of view at the bottom until all rows have been retrieved and the result table scrolled to the end.
This PR fixes the issue by adding a footer to the table where the status is always displayed.