### PR TITLE
Feature/result table column headings

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,13 +51,8 @@
       {
         "id": "vscode-db2i",
         "title": "General",
-        "order": 1,
+        "order": 0,
         "properties": {
-          "vscode-db2i.autoRefreshSelfCodesView": {
-            "type": "boolean",
-            "description": "Enable auto-refresh for SELF Codes view when connecting to a system",
-            "default": false
-          },
           "vscode-db2i.pageSize": {
             "type": "number",
             "description": "Page size for Schema browser",
@@ -68,26 +63,39 @@
             "description": "Name of configuration to use when auto starting a job. 'new' for brand new default job, 'ask' to be asked, 'never' to never start, or a name of a stored configuration",
             "default": "ask"
           },
-          "vscode-db2i.jobSelfDefault": {
-            "type": "string",
-            "description": "Default SELF setting for new jobs",
-            "default": "*NONE",
-            "enum": ["*NONE", "*ALL", "*ERROR", "*WARNING"]
-          },
           "vscode-db2i.jobConfigs": {
             "type": "object",
             "description": "Saved configs for",
             "default": {},
             "additionalProperties": true
+          }
+        }
+      },
+      {
+        "id": "vscode-db2i.self",
+        "title": "SQL Error Logging Facility (SELF)",
+        "properties": {
+          "vscode-db2i.jobSelfDefault": {
+            "type": "string",
+            "order": 0,
+            "description": "Default SELF setting for new jobs",
+            "default": "*NONE",
+            "enum": ["*NONE", "*ALL", "*ERROR", "*WARNING"]
           },
-          "vscode-db2i.collapsedResultSet": {
+          "vscode-db2i.autoRefreshSelfCodesView": {
             "type": "boolean",
-            "description": "Make larger cells collapsed by default",
+            "description": "Enable auto-refresh for SELF Codes view when connecting to a system",
             "default": false
-          },
+          }
+        }
+      },
+      {
+        "id": "vscode-db2i.sqlFormat",
+        "title": "SQL Formatting",
+        "properties": {
           "vscode-db2i.sqlFormat.identifierCase": {
             "type": "string",
-            "description": "SQL formatting options: Lowercase or uppercase SQL identifiers",
+            "description": "SQL identifiers",
             "default": "preserve",
             "enum": ["lower", "upper", "preserve"],
             "enumDescriptions": [
@@ -98,7 +106,7 @@
           },
           "vscode-db2i.sqlFormat.keywordCase": {
             "type": "string",
-            "description": "SQL formatting options: Lowercase or uppercase SQL keywords",
+            "description": "SQL keywords",
             "default": "lower",
             "enum": ["lower", "upper"],
             "enumDescriptions": [
@@ -109,9 +117,30 @@
         }
       },
       {
+        "id": "vscode-db2i.resultsets",
+        "title": "Viewing Data",
+        "properties": {
+          "vscode-db2i.resultsets.columnHeadings": {
+            "type": "string",
+            "order": 0,
+            "description": "Descriptor to use for column headings when viewing data",
+            "default": "Name",
+            "enum": ["Name", "Label"],
+            "enumDescriptions": [
+              "Show the column name",
+              "Show the column label\n'Extended metadata' must be set to true in the JDBC configuration"
+            ]
+            },
+          "vscode-db2i.collapsedResultSet": {
+            "type": "boolean",
+            "description": "Make larger cells collapsed by default",
+            "default": false
+          }
+        }
+      },
+      {
         "id": "vscode-db2i.visualExplain",
         "title": "Visual Explain",
-        "order": 2,
         "properties": {
           "vscode-db2i.visualExplain.highlighting": {
             "type": "object",
@@ -576,8 +605,13 @@
         "title": "Open SELF Documentation",
         "category": "Db2 for i",
         "icon": "$(question)"
+      },
+      {
+        "command": "vscode-db2i.resultset.settings",
+        "title": "Settings",
+        "category": "Db2 for i",
+        "icon": "$(gear)"
       }
-
     ],
     "submenus": [
       {
@@ -654,6 +688,10 @@
         },
         {
           "command": "vscode-db2i.dove.node.copy",
+          "when": "never"
+        },
+        {
+          "command": "vscode-db2i.resultset.settings",
           "when": "never"
         }
       ],
@@ -793,6 +831,11 @@
           "command": "vscode-db2i.dove.closeDetails",
           "group": "navigation@1",
           "when": "view == vscode-db2i.dove.node"
+        },
+        {
+          "command": "vscode-db2i.resultset.settings",
+          "group": "navigation",
+          "when": "view == vscode-db2i.resultset"
         }
       ],
       "view/item/context": [

--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
             "title": "Auto-refresh SELF Codes view",
             "description": "Enable auto-refresh for SELF Codes view when connecting to a system",
             "default": false
-          },
+          }
         }
       },
       {

--- a/src/views/results/index.ts
+++ b/src/views/results/index.ts
@@ -78,6 +78,17 @@ export function initialise(context: vscode.ExtensionContext) {
       resultSetProvider.setLoadingText(`View will be active when a statement is executed.`);
     }),
 
+    vscode.commands.registerCommand(`vscode-db2i.resultset.settings`, async () => {
+      vscode.commands.executeCommand('workbench.action.openSettings', 'vscode-db2i.resultsets');
+    }),
+
+    vscode.workspace.onDidChangeConfiguration(e => {
+      // If the result set column headings setting has changed, update the header of the current result set
+      if (e.affectsConfiguration('vscode-db2i.resultsets.columnHeadings')) {
+        resultSetProvider.updateHeader();
+      }
+    }),
+
     vscode.commands.registerCommand(`vscode-db2i.dove.close`, () => {
       doveResultsView.close();
       doveNodeView.close();

--- a/src/views/results/resultSetPanelProvider.ts
+++ b/src/views/results/resultSetPanelProvider.ts
@@ -4,6 +4,7 @@ import { setCancelButtonVisibility } from ".";
 import { JobManager } from "../../config";
 import { Query, QueryState } from "../../connection/query";
 import { updateStatusBar } from "../jobManager/statusBar";
+import Configuration from "../../configuration";
 import * as html from "./html";
 
 export class ResultSetPanelProvider implements WebviewViewProvider {
@@ -41,11 +42,11 @@ export class ResultSetPanelProvider implements WebviewViewProvider {
 
           let queryResults = queryObject.getState() == QueryState.RUN_MORE_DATA_AVAILABLE ? await queryObject.fetchMore() : await queryObject.run();
 
-          data = queryResults.data;
           this._view.webview.postMessage({
             command: `rows`,
             rows: queryResults.data,
-            columnList: queryResults.metadata ? queryResults.metadata.columns.map(x => x.name) : undefined, // Query.fetchMore() doesn't return the metadata
+            columnMetaData: queryResults.metadata ? queryResults.metadata.columns : undefined, // Query.fetchMore() doesn't return the metadata
+            columnHeadings: Configuration.get(`resultsets.columnHeadings`) || 'Name',
             queryId: queryObject.getId(),
             update_count: queryResults.update_count,
             isDone: queryResults.is_done
@@ -98,6 +99,16 @@ export class ResultSetPanelProvider implements WebviewViewProvider {
     }
 
     html.setLoadingText(this._view.webview, content);
+  }
+
+  /** Update the result table column headings based on the configuration setting */
+  async updateHeader() {
+    if (this._view) {
+      this._view.webview.postMessage({
+        command: `header`,
+        columnHeadings: Configuration.get(`resultsets.columnHeadings`) || 'Name',
+      });
+    }
   }
 
   async setScrolling(basicSelect, isCL = false, queryId: string = ``) {


### PR DESCRIPTION
#### Overview
Add support for customizing result column headings.

- [x] New configuration setting for `Column headings`
  - [x] Options are `Name` and `Label`
        Note: `Label` requires the JDBC config 'Extended metadata' setting to be turned on.
- [x] New command for editing the setting from the results view
- [x] Listen for changes to the setting and apply to open results view
- [x] Bonus: Organized the Db2 for i preferences

#### Test
```sql
CREATE SCHEMA TESTHEAD;

CREATE OR REPLACE TABLE TESTHEAD.T1 (
            C1 INTEGER DEFAULT NULL,
            C2 VARCHAR(25) CCSID 37 DEFAULT NULL
        );

LABEL ON COLUMN TESTHEAD.T1 (
    C1 IS 'C1 Column Heading',
    C2 IS 'C2 Column Heading'
);

SELECT * FROM TESTHEAD.T1
```

Closes #127 Ability to toggle file column labels on results view