### PR TITLE
Fix issue with calling qualified procedure

### DIFF
--- a/src/language/providers/completionProvider.ts
+++ b/src/language/providers/completionProvider.ts
@@ -290,12 +290,17 @@ async function getCompletionItemsForTriggerDot(
     }
   } else {
     
+    if (currentStatement.type === StatementType.Call) {
+      const procs = await getProcedures([curRef], getDefaultSchema());
+      list.push(...procs);
 
-    const objectCompletions = await getObjectCompletions(
-      curSchema,
-      completionTypes
-    );
-    list.push(...objectCompletions);
+    } else {
+      const objectCompletions = await getObjectCompletions(
+        curSchema,
+        completionTypes
+      );
+      list.push(...objectCompletions);
+    }
   }
 
   return list;


### PR DESCRIPTION
When using the dot trigger in a `CALL` statement, to get a list of callable procedures in a schema, the list was showing all non-procedure objects.

This will fix it so only procedures are shown.