### PR TITLE
Enable result sets in webviews

### DIFF
--- a/package.json
+++ b/package.json
@@ -315,6 +315,12 @@
         "when": "editorLangId == sql && resourceExtname != .inb"
       },
       {
+        "command": "vscode-db2i.runEditorStatement.inView",
+        "key": "ctrl+alt+r",
+        "mac": "cmd+ctrl+r",
+        "when": "editorLangId == sql"
+      },
+      {
         "command": "vscode-db2i.editorExplain.withRun",
         "key": "ctrl+shift+r",
         "mac": "cmd+shift+r",
@@ -473,6 +479,12 @@
         "title": "Run statement",
         "category": "Db2 for i",
         "icon": "$(notebook-execute)"
+      },
+      {
+        "command": "vscode-db2i.runEditorStatement.inView",
+        "title": "Run statement in new view",
+        "category": "Db2 for i",
+        "icon": "$(window)"
       },
       {
         "command": "vscode-db2i.statement.cancel",
@@ -780,6 +792,11 @@
       "sql/editor/context": [
         {
           "command": "vscode-db2i.runEditorStatement",
+          "when": "editorLangId == sql && vscode-db2i:statementCanCancel != true",
+          "group": "navigation@1"
+        },
+        {
+          "command": "vscode-db2i.runEditorStatement.inView",
           "when": "editorLangId == sql && vscode-db2i:statementCanCancel != true",
           "group": "navigation@1"
         },

--- a/src/connection/manager.ts
+++ b/src/connection/manager.ts
@@ -94,8 +94,8 @@ export class SQLJobManager {
     return this.jobs;
   }
 
-  getJob(name: string): JobInfo | undefined {
-    return this.jobs.find(info => info.name === name);
+  getJob(nameOrId: string): JobInfo | undefined {
+    return this.jobs.find(info => info.name === nameOrId || info.job.id === nameOrId);
   }
 
   setSelection(selectedName: string): JobInfo|undefined {

--- a/src/views/html.ts
+++ b/src/views/html.ts
@@ -67,6 +67,15 @@ export function getHeader(options: {withCollapsed?: boolean} = {}): string {
       min-height: 100vh;
     }
 
+    .primaryButton {
+      background-color: var(--vscode-button-background);
+      color: var(--vscode-button-foreground);
+      border: none;
+      border-radius: 5px;
+      padding: 5px 10px;
+      cursor: pointer;
+    }
+
     /* https://cssloaders.github.io */
     .loader {
       width: 32px;

--- a/src/views/results/html.ts
+++ b/src/views/results/html.ts
@@ -38,7 +38,7 @@ export function getLoadingHTML(): string {
   `;
 }
 
-export function generateScroller(basicSelect: string, isCL: boolean): string {
+export function generateScroller(basicSelect: string, isCL: boolean, withCancel?: boolean): string {
   const withCollapsed = Configuration.get<boolean>('collapsedResultSet');
 
   return /*html*/`
@@ -121,6 +121,17 @@ export function generateScroller(basicSelect: string, isCL: boolean): string {
                   break;
               }
             });
+
+            const cancelButton = document.getElementById('cancelButton');
+
+            if (cancelButton) {
+              cancelButton.addEventListener('click', () => {
+                vscode.postMessage({
+                  command: 'cancel',
+                  queryId: myQueryId
+                });
+              });
+            }
           }
 
           function fetchNextPage() {
@@ -206,6 +217,7 @@ export function generateScroller(basicSelect: string, isCL: boolean): string {
         <div id="spinnerContent" class="center-screen">
           <p id="loadingText">Running statement</p>
           <span class="loader"></span>
+          ${withCancel ? `<button id="cancelButton" class="primaryButton">Cancel</button>` : ``}
         </div>
       </body>
     </html>

--- a/src/views/results/index.ts
+++ b/src/views/results/index.ts
@@ -1,4 +1,4 @@
-import vscode, { SnippetString, ViewColumn, TreeView } from "vscode"
+import vscode, { SnippetString, ViewColumn, TreeView, window } from "vscode"
 
 import * as csv from "csv/sync";
 
@@ -141,6 +141,7 @@ export function initialise(context: vscode.ExtensionContext) {
 
     vscode.commands.registerCommand(`vscode-db2i.editorExplain.withRun`, (options?: StatementInfo) => { runHandler({ qualifier: `explain`, ...options }) }),
     vscode.commands.registerCommand(`vscode-db2i.editorExplain.withoutRun`, (options?: StatementInfo) => { runHandler({ qualifier: `onlyexplain`, ...options }) }),
+    vscode.commands.registerCommand(`vscode-db2i.runEditorStatement.inView`, (options?: StatementInfo) => { runHandler({ viewColumn: ViewColumn.Beside, ...options }) }),
     vscode.commands.registerCommand(`vscode-db2i.runEditorStatement`, (options?: StatementInfo) => { runHandler(options) })
   )
 }
@@ -155,6 +156,13 @@ async function runHandler(options?: StatementInfo) {
 
   if (optionsIsValid || (editor && editor.document.languageId === `sql`)) {
     await resultSetProvider.ensureActivation();
+    let chosenView = resultSetProvider;
+
+    const useWindow = (title: string, column?: ViewColumn) => {
+      const webview = window.createWebviewPanel(`sqlResultSet`, title, column || ViewColumn.Two, {retainContextWhenHidden: true, enableScripts: true, enableFindWidget: true});
+      chosenView = new ResultSetPanelProvider();
+      chosenView.resolveWebviewView(webview);
+    }
 
     const statementDetail = parseStatement(editor, optionsIsValid ? options : undefined);
 
@@ -178,10 +186,15 @@ async function runHandler(options?: StatementInfo) {
     }
 
     const statement = statementDetail.statement;
+    const refs = statement.getObjectReferences();
+    const ref = refs[0];
+
+    let possibleTitle = `SQL Results`;
+    if (ref && ref.object.name) {
+      possibleTitle = (ref.object.schema ? ref.object.schema + `.` : ``) + ref.object.name;
+    }
 
     if (statement.type === StatementType.Create || statement.type === StatementType.Alter) {
-      const refs = statement.getObjectReferences();
-      const ref = refs[0];
       const databaseObj =
         statement.type === StatementType.Create && ref.createType.toUpperCase() === `schema`
           ? ref.object.schema || ``
@@ -192,10 +205,16 @@ async function runHandler(options?: StatementInfo) {
     if (statementDetail.content.trim().length > 0) {
       try {
         if (statementDetail.qualifier === `cl`) {
-          resultSetProvider.setScrolling(statementDetail.content, true); // Never errors
+          if (options && options.viewColumn) {
+            useWindow(`CL results`, options.viewColumn);
+          }
+          chosenView.setScrolling(statementDetail.content, true); // Never errors
         } else if (statementDetail.qualifier === `statement`) {
           // If it's a basic statement, we can let it scroll!
-          resultSetProvider.setScrolling(statementDetail.content); // Never errors
+          if (options && options.viewColumn) {
+            useWindow(possibleTitle, options.viewColumn);
+          }
+          chosenView.setScrolling(statementDetail.content); // Never errors
 
         } else if ([`explain`, `onlyexplain`].includes(statementDetail.qualifier)) {
           // If it's an explain, we need to 
@@ -203,7 +222,7 @@ async function runHandler(options?: StatementInfo) {
           if (selectedJob) {
             const onlyExplain = statementDetail.qualifier === `onlyexplain`;
 
-            resultSetProvider.setLoadingText(onlyExplain ? `Explaining without running...` : `Explaining...`);
+            chosenView.setLoadingText(onlyExplain ? `Explaining without running...` : `Explaining...`);
             const explainType: ExplainType = onlyExplain ? ExplainType.DoNotRun : ExplainType.Run;
 
               setCancelButtonVisibility(true);
@@ -211,9 +230,9 @@ async function runHandler(options?: StatementInfo) {
               setCancelButtonVisibility(false);
 
             if (onlyExplain) {
-              resultSetProvider.setLoadingText(`Explained.`, false);
+              chosenView.setLoadingText(`Explained.`, false);
             } else {
-              resultSetProvider.setScrolling(statementDetail.content, false, explained.id); // Never errors
+              chosenView.setScrolling(statementDetail.content, false, explained.id); // Never errors
             }
 
             explainTree = new ExplainTree(explained.vedata);
@@ -226,7 +245,7 @@ async function runHandler(options?: StatementInfo) {
           }
         } else {
           // Otherwise... it's a bit complicated.
-          resultSetProvider.setLoadingText(`Executing SQL statement...`, false);
+          chosenView.setLoadingText(`Executing SQL statement...`, false);
 
           setCancelButtonVisibility(true);
           updateStatusBar({executing: true});
@@ -279,13 +298,13 @@ async function runHandler(options?: StatementInfo) {
 
                 const textDoc = await vscode.workspace.openTextDocument({ language: statementDetail.qualifier, content });
                 await vscode.window.showTextDocument(textDoc);
-                resultSetProvider.setLoadingText(`Query executed with ${data.length} rows returned.`, false);
+                chosenView.setLoadingText(`Query executed with ${data.length} rows returned.`, false);
                 break;
             }
 
           } else {
             vscode.window.showInformationMessage(`Statement executed with no data returned.`);
-            resultSetProvider.setLoadingText(`Statement executed with no data returned.`);
+            chosenView.setLoadingText(`Statement executed with no data returned.`);
           }
         }
 
@@ -304,7 +323,7 @@ async function runHandler(options?: StatementInfo) {
         }
 
         if ([`statement`, `explain`, `onlyexplain`].includes(statementDetail.qualifier) && statementDetail.history !== false) {
-          resultSetProvider.setError(errorText);
+          chosenView.setError(errorText);
         } else {
           vscode.window.showErrorMessage(errorText);
         }

--- a/src/views/results/index.ts
+++ b/src/views/results/index.ts
@@ -147,6 +147,10 @@ export function initialise(context: vscode.ExtensionContext) {
 }
 
 async function runHandler(options?: StatementInfo) {
+  if (options === undefined || options.viewColumn === undefined) {
+    await resultSetProvider.ensureActivation();
+  }
+
   // Options here can be a vscode.Uri when called from editor context.
   // But that isn't valid here.
   const optionsIsValid = (options?.content !== undefined);
@@ -155,7 +159,6 @@ async function runHandler(options?: StatementInfo) {
   vscode.commands.executeCommand('vscode-db2i.dove.close');
 
   if (optionsIsValid || (editor && editor.document.languageId === `sql`)) {
-    await resultSetProvider.ensureActivation();
     let chosenView = resultSetProvider;
 
     const useWindow = (title: string, column?: ViewColumn) => {

--- a/src/views/results/index.ts
+++ b/src/views/results/index.ts
@@ -57,8 +57,8 @@ export function initialise(context: vscode.ExtensionContext) {
       webviewOptions: { retainContextWhenHidden: true },
     }),
 
-    vscode.commands.registerCommand(`vscode-db2i.statement.cancel`, async () => {
-      const selected = JobManager.getSelection();
+    vscode.commands.registerCommand(`vscode-db2i.statement.cancel`, async (jobName?: string) => {
+      const selected = typeof jobName === `string` ? JobManager.getJob(jobName) : JobManager.getSelection();
       if (selected) {
         updateStatusBar({canceling: true});
         const cancelled = await selected.job.requestCancel();

--- a/src/views/results/index.ts
+++ b/src/views/results/index.ts
@@ -207,17 +207,20 @@ async function runHandler(options?: StatementInfo) {
 
     if (statementDetail.content.trim().length > 0) {
       try {
+        const inWindow = Boolean(options && options.viewColumn);
+
         if (statementDetail.qualifier === `cl`) {
-          if (options && options.viewColumn) {
+          if (inWindow) {
             useWindow(`CL results`, options.viewColumn);
           }
           chosenView.setScrolling(statementDetail.content, true); // Never errors
+          
         } else if (statementDetail.qualifier === `statement`) {
           // If it's a basic statement, we can let it scroll!
-          if (options && options.viewColumn) {
+          if (inWindow) {
             useWindow(possibleTitle, options.viewColumn);
           }
-          chosenView.setScrolling(statementDetail.content); // Never errors
+          chosenView.setScrolling(statementDetail.content, false, undefined, inWindow); // Never errors
 
         } else if ([`explain`, `onlyexplain`].includes(statementDetail.qualifier)) {
           // If it's an explain, we need to 

--- a/src/views/results/resultSetPanelProvider.ts
+++ b/src/views/results/resultSetPanelProvider.ts
@@ -68,8 +68,7 @@ export class ResultSetPanelProvider implements WebviewViewProvider {
                 // We will need to revisit this if we ever allow multiple result tabs like ACS does
                 // Query.cleanup();
 
-                let query = await JobManager.getPagingStatement(message.query, { isClCommand: message.isCL, autoClose: true, isTerseResults: true });
-                this.currentQuery = query;
+                this.currentQuery = await JobManager.getPagingStatement(message.query, { isClCommand: message.isCL, autoClose: true, isTerseResults: true });
               }
 
               let queryResults = this.currentQuery.getState() == QueryState.RUN_MORE_DATA_AVAILABLE ? await this.currentQuery.fetchMore() : await this.currentQuery.run();


### PR DESCRIPTION
Adds a new button the execute dropdown to run the statement in a new view.

This will run the statement in a brand new tab instead of the standard webview.