### PR TITLE
activate vscode-data-table extension for notebooks

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,9 @@
     "onLanguage:sql"
   ],
   "extensionDependencies": [
-    "halcyontechltd.code-for-ibmi"
+    "halcyontechltd.code-for-ibmi",
+    "RandomFractalsInc.vscode-data-table"
+
   ],
   "main": "./dist/extension.js",
   "contributes": {

--- a/src/notebooks/Controller.ts
+++ b/src/notebooks/Controller.ts
@@ -125,7 +125,7 @@ export class IBMiController {
                 }
 
                 if (fallbackToTable) {
-                  items.push(vscode.NotebookCellOutputItem.text(JSON.stringify(table), `text/plain`));
+                  items.push(vscode.NotebookCellOutputItem.text(JSON.stringify(table, null, 2), `application/json`));
                 }
               } else {
                 items.push(vscode.NotebookCellOutputItem.stderr(`No rows returned from statement.`));

--- a/src/notebooks/Controller.ts
+++ b/src/notebooks/Controller.ts
@@ -67,7 +67,10 @@ export class IBMiController {
     const execution = this._controller.createNotebookCellExecution(cell);
     execution.executionOrder = ++this._executionOrder;
     execution.start(Date.now()); // Keep track of elapsed time to execute cell.
-
+    if (cell.outputs.length > 0) {
+      execution.clearOutput();
+    }
+    
     const selected = JobManager.getSelection();
 
     execution.token.onCancellationRequested(() => {

--- a/src/notebooks/Controller.ts
+++ b/src/notebooks/Controller.ts
@@ -10,6 +10,10 @@ import { JobStatus } from '../connection/sqlJob';
 import { ChartDetail, generateChart } from './logic/chart';
 import { getStatementDetail } from './logic/statement';
 
+async function dataTableExtentionActivation() {
+  await vscode.extensions.getExtension('RandomFractalsInc.vscode-data-table')?.activate();
+}
+
 export class IBMiController {
   readonly controllerId = `db2i-notebook-controller-id`;
   readonly notebookType = `db2i-notebook`;
@@ -26,6 +30,9 @@ export class IBMiController {
       this.notebookType,
       this.label
     );
+
+    // activate vscode-data-table extention
+    dataTableExtentionActivation();
 
     this._controller.supportedLanguages = this.supportedLanguages;
     this._controller.supportsExecutionOrder = true;
@@ -115,7 +122,7 @@ export class IBMiController {
                 }
 
                 if (fallbackToTable) {
-                  items.push(vscode.NotebookCellOutputItem.text(mdTable(table, columns), `text/markdown`));
+                  items.push(vscode.NotebookCellOutputItem.text(JSON.stringify(table), `text/plain`));
                 }
               } else {
                 items.push(vscode.NotebookCellOutputItem.stderr(`No rows returned from statement.`));


### PR DESCRIPTION
## render tables with vscode-data-table extension
- https://github.com/RandomFractals/vscode-data-table

![image](https://github.com/codefori/vscode-db2i/assets/50843283/fa3517ed-6b68-4e82-9860-12f147e06c37)

Column stats:
![image](https://github.com/codefori/vscode-db2i/assets/50843283/0e4c4f6c-5a5f-43a6-a8ce-583b30b215df)

![image](https://github.com/codefori/vscode-db2i/assets/50843283/0aba5932-3bc7-4bb0-85cd-db0a1b7a58ec)

