### PR TITLE
integrate data preview extension

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
     "onLanguage:sql"
   ],
   "extensionDependencies": [
-    "halcyontechltd.code-for-ibmi"
+    "halcyontechltd.code-for-ibmi",
+    "RandomFractalsInc.vscode-data-preview"
   ],
   "main": "./dist/extension.js",
   "contributes": {


### PR DESCRIPTION
Addresses #240 

TODO:
- Add command to Run Dialog to open Data Preview
- review `preview` logic
- add data preview extension as dependency, or check if the extension exists
    - show message to user that `preview` requires data preview extension installed
- use `vscode.fs` instead of `fs/promises`
