### PR TITLE
Ability to toggle self for specific job

### DIFF
--- a/package.json
+++ b/package.json
@@ -390,8 +390,20 @@
         "icon": "$(sync-ignored)"
       },
       {
+        "command": "vscode-db2i.self.enableSelectedJobOnly",
+        "title": "Show Selected Job Only",
+        "category": "Db2 for i",
+        "icon": "$(filter)"
+      },
+      {
+        "command": "vscode-db2i.self.disableSelectedJobOnly",
+        "title": "Show errors for user (all jobs)",
+        "category": "Db2 for i",
+        "icon": "$(account)"
+      },
+      {
         "command": "vscode-db2i.self.reset",
-        "title": "Reset SELF Codes View",
+        "title": "Clear SELF Codes",
         "category": "Db2 for i",
         "icon": "$(trash)"
       },
@@ -846,6 +858,16 @@
           "command": "vscode-db2i.self.disableAutoRefresh",
           "group": "navigation@2",
           "when": "view == vscode-db2i.self.nodes && vscode-db2i.self.autoRefresh == true"
+        },
+        {
+          "command": "vscode-db2i.self.enableSelectedJobOnly",
+          "group": "navigation@2",
+          "when": "view == vscode-db2i.self.nodes && vscode-db2i.self.specificJob == false"
+        },
+        {
+          "command": "vscode-db2i.self.disableSelectedJobOnly",
+          "group": "navigation@2",
+          "when": "view == vscode-db2i.self.nodes && vscode-db2i.self.specificJob == true"
         },
         {
           "command": "vscode-db2i.self.reset",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -84,6 +84,7 @@ export function activate(context: vscode.ExtensionContext): Db2i {
 
   instance.onEvent(`connected`, () => {
     selfCodesView.setRefreshEnabled(false);
+    selfCodesView.setJobOnly(false);
     // Refresh the examples when we have it, so we only display certain examples
     onConnectOrServerInstall().then(() => {
       exampleBrowser.refresh();

--- a/src/views/jobManager/selfCodes/selfCodesResultsView.ts
+++ b/src/views/jobManager/selfCodes/selfCodesResultsView.ts
@@ -31,13 +31,19 @@ export class selfCodesResultsView implements TreeDataProvider<any> {
       vscode.commands.registerCommand(`vscode-db2i.self.reset`, async () => {
         const selected = JobManager.getRunningJobs();
         if (selected) {
+          const resetCmd = this.selectedJobOnly
+            ? `DELETE FROM qsys2.SQL_ERRORT where job_name = '${selected[0].job.id}'`
+            : `DELETE FROM qsys2.SQL_ERRORT where user_name = current_user`;
+
           try {
-            const resetSelfCmd = `DELETE FROM qsys2.SQL_ERRORT where user_name = current_user`
-            await JobManager.runSQL(resetSelfCmd, undefined);
+            await JobManager.runSQL(resetCmd, undefined);
             this.refresh();
-            vscode.window.showInformationMessage(`Reset SELF code error log.`)
+            const message = this.selectedJobOnly
+              ? `Reset SELF code error log for job ${selected[0].name}.`
+              : `Reset SELF code error log for all jobs.`;
+            vscode.window.showInformationMessage(message);
           } catch (e) {
-            vscode.window.showErrorMessage(`An Error occured reseting SELF code error log: ${e}`)
+            vscode.window.showErrorMessage(`An Error occurred resetting SELF code error log: ${e}`);
           }
         }
       }),

--- a/src/views/jobManager/selfCodes/selfCodesResultsView.ts
+++ b/src/views/jobManager/selfCodes/selfCodesResultsView.ts
@@ -155,13 +155,9 @@ export class selfCodesResultsView implements TreeDataProvider<any> {
             new JobLogEntiresItem(selected.job)
           ];
         } else {
-          const selfCodes = await this.getSelfCodes(selected, this.selectedJobOnly);
-          if (selfCodes) {
-            return selfCodes.map((error) => {
-              const treeItem = new SelfCodeTreeItem(error);
-              return treeItem;
-            });
-          }
+          const selfCodeItems = new SelfCodeItems(this, selected);
+          const jobLogItems = await selfCodeItems.getChildren();
+          return jobLogItems;
         }
       }
 

--- a/src/views/jobManager/selfCodes/selfCodesResultsView.ts
+++ b/src/views/jobManager/selfCodes/selfCodesResultsView.ts
@@ -65,7 +65,13 @@ export class selfCodesResultsView implements TreeDataProvider<any> {
       }),
       vscode.commands.registerCommand(`vscode-db2i.self.help`, async () => {
         await vscode.commands.executeCommand(`vscode.open`, `https://www.ibm.com/docs/en/i/7.5?topic=tools-sql-error-logging-facility-self`)
-      })
+      }),
+      vscode.commands.registerCommand(`vscode-db2i.self.enableSelectedJobOnly`, async () => {
+        this.setJobOnly(true);
+      }),
+      vscode.commands.registerCommand(`vscode-db2i.self.disableSelectedJobOnly`, async () => {
+        this.setJobOnly(false);
+      }),
     );
     setInterval(async () => {
       if (this.autoRefresh) {
@@ -86,6 +92,12 @@ export class selfCodesResultsView implements TreeDataProvider<any> {
     if (withMessage) {
       vscode.window.showInformationMessage(`SELF Code Auto Refresh ${enabled ? 'Enabled' : 'Disabled'}`);
     }
+  }
+
+  setJobOnly(enabled: boolean): void {
+    this.selectedJobOnly = enabled;
+    vscode.commands.executeCommand(`setContext`, `vscode-db2i.self.specificJob`, enabled);
+    this.refresh();
   }
 
   async getSelfCodes(selected: JobInfo, onlySelected?: boolean): Promise<SelfCodeNode[]|undefined> {


### PR DESCRIPTION
This PR adds the ability to toggle SELF to only show SELF logs for the selected job. 

When it is toggled on, we can also show the job log for the selected job.

![image](https://github.com/user-attachments/assets/6510b97d-4328-4bf5-ab47-0c1695b4561c)

![image](https://github.com/user-attachments/assets/9a5e55b0-ef73-4108-b9ff-85a6188d4066)
