### PR TITLE
SQL Variable view

### DIFF
--- a/package.json
+++ b/package.json
@@ -264,6 +264,13 @@
           "name": "SQL Error Logging Facility (SELF)",
           "when": "code-for-ibmi:connected && vscode-db2i:SELFSupported && vscode-db2i:jobManager == true",
           "visibility": "collapsed"
+        },
+        {
+          "type": "tree",
+          "id": "vscode-db2i.variables",
+          "name": "SQL Variables",
+          "when": "code-for-ibmi:connected && vscode-db2i:jobManager.hasJob",
+          "visibility": "collapsed"
         }
       ],
       "db2-explorer": [
@@ -309,6 +316,10 @@
       {
         "view": "vscode-db2i.self.nodes",
         "contents": "🛠️ SELF Codes will appear here. You can set the SELF log level on specific jobs, or you can set the default for new jobs in the User Settings.\n\n[Set Default for New Jobs](command:vscode-db2i.jobManager.defaultSelfSettings)\n\n[Learn about SELF](command:vscode-db2i.self.help)"
+      },
+      {
+        "view": "vscode-db2i.variables",
+        "contents": "Use this view to quickly see the contents of variables and more.\n\n[Add variable](command:vscode-db2i.variables.add)"
       }
     ],
     "keybindings": [
@@ -398,6 +409,24 @@
         "title": "Reset SELF Codes View",
         "category": "Db2 for i",
         "icon": "$(trash)"
+      },
+      {
+        "command": "vscode-db2i.variables.add",
+        "title": "Add Variable",
+        "category": "Db2 for i",
+        "icon": "$(symbol-variable)"
+      },
+      {
+        "command": "vscode-db2i.variables.refresh",
+        "title": "Refresh",
+        "category": "Db2 for i",
+        "icon": "$(refresh)"
+      },
+      {
+        "command": "vscode-db2i.variables.remove",
+        "title": "Remove",
+        "category": "Db2 for i",
+        "icon": "$(remove)"
       },
       {
         "command": "vscode-db2i.manageSchemaBrowserList",
@@ -872,6 +901,16 @@
           "when": "view == vscode-db2i.self.nodes"
         },
         {
+          "command": "vscode-db2i.variables.add",
+          "group": "navigation",
+          "when": "view == vscode-db2i.variables"
+        },
+        {
+          "command": "vscode-db2i.variables.refresh",
+          "group": "navigation",
+          "when": "view == vscode-db2i.variables"
+        },
+        {
           "command": "vscode-db2i.queryHistory.clear",
           "group": "navigation",
           "when": "view == queryHistory"
@@ -974,8 +1013,13 @@
           "group": "inline"
         },
         {
+          "command": "vscode-db2i.variables.remove",
+          "when": "view == vscode-db2i.variables && viewItem == sqlVarValue",
+          "group": "inline"
+        },
+        {
           "command": "vscode-db2i.generateSQL",
-          "when": "viewItem == table || viewItem == view || viewItem == alias || viewItem == constraint || viewItem == function || viewItem == variable || viewItem == index || viewItem == procedure || viewItem == sequence || viewItem == package || viewItem == trigger || viewItem == type",
+          "when": "view == schemaBrowser && (viewItem == table || viewItem == view || viewItem == alias || viewItem == constraint || viewItem == function || viewItem == variable || viewItem == index || viewItem == procedure || viewItem == sequence || viewItem == package || viewItem == trigger || viewItem == type)",
           "group": "db2@2"
         },
         {

--- a/package.json
+++ b/package.json
@@ -1023,6 +1023,11 @@
           "group": "db2@2"
         },
         {
+          "command": "vscode-db2i.variables.add",
+          "group": "navigation",
+          "when": "view == schemaBrowser && viewItem == variable"
+        },
+        {
           "command": "vscode-db2i.removeSchemaFromSchemaBrowser",
           "when": "view == schemaBrowser && viewItem == schema",
           "group": "db2@3"

--- a/package.json
+++ b/package.json
@@ -277,6 +277,13 @@
       ],
       "ibmi-panel": [
         {
+          "type": "tree",
+          "id": "vscode-db2i.variables",
+          "name": "SQL Variables",
+          "when": "code-for-ibmi:connected && vscode-db2i:jobManager.hasJob",
+          "visibility": "collapsed"
+        },
+        {
           "type": "webview",
           "id": "vscode-db2i.resultset",
           "name": "Results",
@@ -828,85 +835,17 @@
           "when": "view == exampleBrowser"
         }
       ],
-      "commandPalette": [
-        {
-          "command": "vscode-db2i.setSchemaFilter",
-          "when": "never"
-        },
-        {
-          "command": "vscode-db2i.resultset.settings",
-          "when": "never"
-        },
-        {
-          "command": "vscode-db2i.dove.displayDetails",
-          "when": "never"
-        },
-        {
-          "command": "vscode-db2i.dove.advisedIndexesAndStatistics",
-          "when": "vscode-db2i:explaining == true"
-        },
-        {
-          "command": "vscode-db2i.dove.editSettings",
-          "when": "vscode-db2i:explaining == true"
-        },
-        {
-          "command": "vscode-db2i.dove.export",
-          "when": "vscode-db2i:explaining == true"
-        },
-        {
-          "command": "vscode-db2i.dove.node.copy",
-          "when": "never"
-        },
-        {
-          "command": "vscode-db2i.queryHistory.remove",
-          "when": "never"
-        },
-        {
-          "command": "vscode-db2i.jobManager.closeJob",
-          "when": "never"
-        },
-        {
-          "command": "vscode-db2i.jobManager.editJobProps",
-          "when": "never"
-        },
-        {
-          "command": "vscode-db2i.jobManager.editSelfCodes",
-          "when": "never"
-        },
-        {
-          "command": "vscode-db2i.jobManager.copyJobId",
-          "when": "never"
-        },
-        {
-          "command": "vscode-db2i.jobManager.viewJobLog",
-          "when": "never"
-        },
-        {
-          "command": "vscode-db2i.jobManager.enableTracing",
-          "when": "never"
-        },
-        {
-          "command": "vscode-db2i.jobManager.getTrace",
-          "when": "never"
-        },
-        {
-          "command": "vscode-db2i.jobManager.newConfig",
-          "when": "never"
-        },
-        {
-          "command": "vscode-db2i.jobManager.editConfig",
-          "when": "never"
-        },
-        {
-          "command": "vscode-db2i.jobManager.deleteConfig",
-          "when": "never"
-        },
-        {
-          "command": "vscode-db2i.notebook.fromSqlUri",
-          "when": "never"
-        }
-      ],
       "view/item/context": [
+        {
+          "command": "vscode-db2i.variables.remove",
+          "when": "view == vscode-db2i.variables && viewItem == sqlVarValue",
+          "group": "inline"
+        },
+        {
+          "command": "vscode-db2i.variables.add",
+          "group": "navigation",
+          "when": "view == schemaBrowser && viewItem == variable"
+        },
         {
           "command": "vscode-db2i.setCurrentSchema",
           "when": "viewItem == schema",
@@ -924,7 +863,7 @@
         },
         {
           "command": "vscode-db2i.generateSQL",
-          "when": "viewItem == table || viewItem == view || viewItem == alias || viewItem == constraint || viewItem == function || viewItem == variable || viewItem == index || viewItem == procedure || viewItem == sequence || viewItem == package || viewItem == trigger || viewItem == type",
+          "when": "view == schemaBrowser && (viewItem == table || viewItem == view || viewItem == alias || viewItem == constraint || viewItem == function || viewItem == variable || viewItem == index || viewItem == procedure || viewItem == sequence || viewItem == package || viewItem == trigger || viewItem == type)",
           "group": "db2@2"
         },
         {
@@ -1052,6 +991,84 @@
           "group": "navigation"
         }
       ],
+      "commandPalette": [
+        {
+          "command": "vscode-db2i.setSchemaFilter",
+          "when": "never"
+        },
+        {
+          "command": "vscode-db2i.resultset.settings",
+          "when": "never"
+        },
+        {
+          "command": "vscode-db2i.dove.displayDetails",
+          "when": "never"
+        },
+        {
+          "command": "vscode-db2i.dove.advisedIndexesAndStatistics",
+          "when": "vscode-db2i:explaining == true"
+        },
+        {
+          "command": "vscode-db2i.dove.editSettings",
+          "when": "vscode-db2i:explaining == true"
+        },
+        {
+          "command": "vscode-db2i.dove.export",
+          "when": "vscode-db2i:explaining == true"
+        },
+        {
+          "command": "vscode-db2i.dove.node.copy",
+          "when": "never"
+        },
+        {
+          "command": "vscode-db2i.queryHistory.remove",
+          "when": "never"
+        },
+        {
+          "command": "vscode-db2i.jobManager.closeJob",
+          "when": "never"
+        },
+        {
+          "command": "vscode-db2i.jobManager.editJobProps",
+          "when": "never"
+        },
+        {
+          "command": "vscode-db2i.jobManager.editSelfCodes",
+          "when": "never"
+        },
+        {
+          "command": "vscode-db2i.jobManager.copyJobId",
+          "when": "never"
+        },
+        {
+          "command": "vscode-db2i.jobManager.viewJobLog",
+          "when": "never"
+        },
+        {
+          "command": "vscode-db2i.jobManager.enableTracing",
+          "when": "never"
+        },
+        {
+          "command": "vscode-db2i.jobManager.getTrace",
+          "when": "never"
+        },
+        {
+          "command": "vscode-db2i.jobManager.newConfig",
+          "when": "never"
+        },
+        {
+          "command": "vscode-db2i.jobManager.editConfig",
+          "when": "never"
+        },
+        {
+          "command": "vscode-db2i.jobManager.deleteConfig",
+          "when": "never"
+        },
+        {
+          "command": "vscode-db2i.notebook.fromSqlUri",
+          "when": "never"
+        }
+      ],
       "editor/title": [
         {
           "when": "editorLangId == sql && code-for-ibmi:connected == true && vscode-db2i:statementCanCancel != true",
@@ -1099,6 +1116,24 @@
         }
       ]
     },
+    "viewsWelcome": [
+      {
+        "view": "vscode-db2i.variables",
+        "contents": "Use this view to quickly see the contents of variables and more.\n\n[Add variable](command:vscode-db2i.variables.add)"
+      },
+      {
+        "view": "queryHistory",
+        "contents": "Statement history will appear here."
+      },
+      {
+        "view": "jobManager",
+        "contents": "The SQL Job Manager allows you to provision one or more jobs for running SQL statements, each with its own connection settings.\n\nUsing managed jobs reduces the use of system resources, improves performance, and maintains  state across subsequent SQL statements.\n\nYou can run SQL statements without starting a job, just be aware that every statement you run requires a temporary, single-use job to be started on your behalf. \n[New SQL job](command:vscode-db2i.jobManager.newJob)"
+      },
+      {
+        "view": "vscode-db2i.self.nodes",
+        "contents": "🛠️ SELF Codes will appear here. You can set the SELF log level on specific jobs, or you can set the default for new jobs in the User Settings.\n\n[Set Default for New Jobs](command:vscode-db2i.jobManager.defaultSelfSettings)\n\n[Learn about SELF](command:vscode-db2i.self.help)"
+      }
+    ],
     "submenus": [
       {
         "icon": "$(notebook-execute)",
@@ -1210,20 +1245,6 @@
           "dark": "#bd8c8c",
           "light": "#5976df"
         }
-      }
-    ],
-    "viewsWelcome": [
-      {
-        "view": "queryHistory",
-        "contents": "Statement history will appear here."
-      },
-      {
-        "view": "jobManager",
-        "contents": "The SQL Job Manager allows you to provision one or more jobs for running SQL statements, each with its own connection settings.\n\nUsing managed jobs reduces the use of system resources, improves performance, and maintains  state across subsequent SQL statements.\n\nYou can run SQL statements without starting a job, just be aware that every statement you run requires a temporary, single-use job to be started on your behalf. \n[New SQL job](command:vscode-db2i.jobManager.newJob)"
-      },
-      {
-        "view": "vscode-db2i.self.nodes",
-        "contents": "🛠️ SELF Codes will appear here. You can set the SELF log level on specific jobs, or you can set the default for new jobs in the User Settings.\n\n[Set Default for New Jobs](command:vscode-db2i.jobManager.defaultSelfSettings)\n\n[Learn about SELF](command:vscode-db2i.self.help)"
       }
     ],
     "notebooks": [

--- a/src/Storage.ts
+++ b/src/Storage.ts
@@ -1,7 +1,8 @@
 import vscode from 'vscode';
 
 const QUERIES_KEY = `queries`;
-const SERVERCOMPONENT_KEY = `serverVersion`
+const SERVERCOMPONENT_KEY = `serverVersion`;
+const VARIABLES_KEY = `variables`;
 
 export interface QueryHistoryItem {
   query: string;
@@ -29,7 +30,7 @@ abstract class Storage {
 }
 
 export class ConnectionStorage extends Storage {
-  private connectionName: string = "";
+  private connectionName: string|undefined;
   constructor(context: vscode.ExtensionContext) {
     super(context);
   }
@@ -43,11 +44,12 @@ export class ConnectionStorage extends Storage {
     }
   }
 
-  setConnectionName(connectionName: string) {
+  setConnectionName(connectionName?: string) {
     this.connectionName = connectionName;
   }
 
   protected getStorageKey(key: string): string {
+    if (!this.connectionName) throw new Error(`Connection name not set. Accessing config too early.`);
     return `${this.connectionName}.${key}`;
   }
 
@@ -85,4 +87,11 @@ export class ConnectionStorage extends Storage {
     await this.set(QUERIES_KEY, sourceList);
   }
 
+  async setVariables<T>(variables: T[]) {
+    await this.set(VARIABLES_KEY, variables);
+  }
+
+  getVariables<T>(): T[] | undefined {
+    return this.get<T[]>(VARIABLES_KEY) || [];
+  }
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -18,8 +18,6 @@ export let JobManager: SQLJobManager = new SQLJobManager();
 export async function onConnectOrServerInstall(): Promise<boolean> {
   const instance = getInstance();
 
-  Config.setConnectionName(instance.getConnection().currentConnectionName);
-
   await Config.fixPastQueries();
 
   osDetail = new IBMiDetail();

--- a/src/connection/serverComponent.ts
+++ b/src/connection/serverComponent.ts
@@ -71,10 +71,6 @@ export class ServerComponent {
       return false;
     }
 
-    if (!Config.ready) {
-      Config.setConnectionName(connection.currentConnectionName);
-    }
-
     if (!this.installed) {
       this.installed = await this.isAlreadyInstalled();
     }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -90,8 +90,11 @@ export function activate(context: vscode.ExtensionContext): Db2i {
 
   const instance = getInstance();
 
-  instance.onEvent(`connected`, () => {
+  instance.onEvent(`disconnected`, () => {
     variablesView.clear();
+  })
+
+  instance.onEvent(`connected`, () => {
     selfCodesView.setRefreshEnabled(false);
     selfCodesView.setJobOnly(false);
     // Refresh the examples when we have it, so we only display certain examples

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -20,6 +20,7 @@ import { SQLJob } from "./connection/sqlJob";
 import { notebookInit } from "./notebooks/IBMiSerializer";
 import { SelfTreeDecorationProvider, selfCodesResultsView } from "./views/jobManager/selfCodes/selfCodesResultsView";
 import Configuration from "./configuration";
+import { Variables } from "./views/variables";
 
 export interface Db2i {
   sqlJobManager: SQLJobManager,
@@ -38,6 +39,7 @@ export function activate(context: vscode.ExtensionContext): Db2i {
   loadBase();
 
   const exampleBrowser = new ExampleBrowser(context);
+  const variablesView = new Variables(context);
   const selfCodesView = new selfCodesResultsView(context);
 
   context.subscriptions.push(
@@ -63,6 +65,10 @@ export function activate(context: vscode.ExtensionContext): Db2i {
     vscode.window.registerTreeDataProvider(
       'vscode-db2i.self.nodes',
       selfCodesView
+    ),
+    vscode.window.registerTreeDataProvider(
+      'vscode-db2i.variables',
+      variablesView
     ),
     vscode.window.registerFileDecorationProvider(
       new SelfTreeDecorationProvider()

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -29,6 +29,7 @@ export interface Db2i {
 
 // this method is called when your extension is activated
 // your extension is activated the very first time the command is executed
+export let variablesView: Variables;
 
 export function activate(context: vscode.ExtensionContext): Db2i {
   
@@ -39,8 +40,9 @@ export function activate(context: vscode.ExtensionContext): Db2i {
   loadBase();
 
   const exampleBrowser = new ExampleBrowser(context);
-  const variablesView = new Variables(context);
   const selfCodesView = new selfCodesResultsView(context);
+
+  variablesView = new Variables(context);
 
   context.subscriptions.push(
     ...languageInit(),
@@ -89,6 +91,7 @@ export function activate(context: vscode.ExtensionContext): Db2i {
   const instance = getInstance();
 
   instance.onEvent(`connected`, () => {
+    variablesView.clear();
     selfCodesView.setRefreshEnabled(false);
     // Refresh the examples when we have it, so we only display certain examples
     onConnectOrServerInstall().then(() => {

--- a/src/notebooks/Controller.ts
+++ b/src/notebooks/Controller.ts
@@ -9,6 +9,7 @@ import { ChartJsType, chartJsTypes, generateChartHTMLCell } from './logic/chartJ
 import { JobStatus } from '../connection/sqlJob';
 import { ChartDetail, generateChart } from './logic/chart';
 import { getStatementDetail } from './logic/statement';
+import { variablesView } from '../extension';
 
 export class IBMiController {
   readonly controllerId = `db2i-notebook-controller-id`;
@@ -50,6 +51,8 @@ export class IBMiController {
         await this._doExecution(cell);
       }
     }
+
+    variablesView.refresh();
   }
 
   private async _doExecution(cell: vscode.NotebookCell): Promise<void> {

--- a/src/views/jobManager/jobManagerView.ts
+++ b/src/views/jobManager/jobManagerView.ts
@@ -304,6 +304,11 @@ export class JobManagerView implements TreeDataProvider<any> {
     commands.executeCommand(`setContext`, `vscode-db2i:jobManager.hasJob`, selectedJob !== undefined);
   }
 
+  async endSession() {
+    await JobManager.endAll();
+    this.refresh();
+  }
+
   getTreeItem(element: vscode.TreeItem) {
     return element;
   }

--- a/src/views/queryHistoryView/index.ts
+++ b/src/views/queryHistoryView/index.ts
@@ -1,7 +1,6 @@
 import vscode, { MarkdownString, ThemeIcon, TreeItem, window, workspace } from "vscode";
 import { TreeDataProvider } from "vscode";
 import { Config } from "../../config";
-import { QueryHistoryItem } from "../../Storage";
 
 const openSqlDocumentCommand = `vscode-db2i.openSqlDocument`;
 

--- a/src/views/schemaBrowser/contributes.json
+++ b/src/views/schemaBrowser/contributes.json
@@ -134,7 +134,7 @@
         },
         {
           "command": "vscode-db2i.generateSQL",
-          "when": "viewItem == table || viewItem == view || viewItem == alias || viewItem == constraint || viewItem == function || viewItem == variable || viewItem == index || viewItem == procedure || viewItem == sequence || viewItem == package || viewItem == trigger || viewItem == type",
+          "when": "view == schemaBrowser && (viewItem == table || viewItem == view || viewItem == alias || viewItem == constraint || viewItem == function || viewItem == variable || viewItem == index || viewItem == procedure || viewItem == sequence || viewItem == package || viewItem == trigger || viewItem == type)",
           "group": "db2@2"
         },
         {

--- a/src/views/schemaBrowser/index.ts
+++ b/src/views/schemaBrowser/index.ts
@@ -538,7 +538,7 @@ class SchemaItem extends vscode.TreeItem {
   }
 }
 
-class SQLObject extends vscode.TreeItem {
+export class SQLObject extends vscode.TreeItem {
   path: string;
   schema: string;
   name: string;

--- a/src/views/variables/contributes.json
+++ b/src/views/variables/contributes.json
@@ -1,0 +1,67 @@
+{
+  "contributes": {
+    "views": {
+      "ibmi-panel": [
+        {
+          "type": "tree",
+          "id": "vscode-db2i.variables",
+          "name": "SQL Variables",
+          "when": "code-for-ibmi:connected && vscode-db2i:jobManager.hasJob",
+          "visibility": "collapsed"
+        }
+      ]
+    },
+    "viewsWelcome": [
+      {
+        "view": "vscode-db2i.variables",
+        "contents": "Use this view to quickly see the contents of variables and more.\n\n[Add variable](command:vscode-db2i.variables.add)"
+      }
+    ],
+    "commands": [
+      {
+        "command": "vscode-db2i.variables.add",
+        "title": "Add Variable",
+        "category": "Db2 for i",
+        "icon": "$(symbol-variable)"
+      },
+      {
+        "command": "vscode-db2i.variables.refresh",
+        "title": "Refresh",
+        "category": "Db2 for i",
+        "icon": "$(refresh)"
+      },
+      {
+        "command": "vscode-db2i.variables.remove",
+        "title": "Remove",
+        "category": "Db2 for i",
+        "icon": "$(remove)"
+      }
+    ],
+    "menus": {
+      "view/title": [
+        {
+          "command": "vscode-db2i.variables.add",
+          "group": "navigation",
+          "when": "view == vscode-db2i.variables"
+        },
+        {
+          "command": "vscode-db2i.variables.refresh",
+          "group": "navigation",
+          "when": "view == vscode-db2i.variables"
+        }
+      ],
+      "view/item/context": [
+        {
+          "command": "vscode-db2i.variables.remove",
+          "when": "view == vscode-db2i.variables && viewItem == sqlVarValue",
+          "group": "inline"
+        },
+        {
+          "command": "vscode-db2i.variables.add",
+          "group": "navigation",
+          "when": "view == schemaBrowser && viewItem == variable"
+        }
+      ]
+    }
+  }
+}

--- a/src/views/variables/index.ts
+++ b/src/views/variables/index.ts
@@ -135,24 +135,24 @@ export class Variables implements TreeDataProvider<any> {
 
   setSuggestion(sqlStatement: string) {
     const alreadyExists = this.variables.some(v => v.statement === sqlStatement);
-    if (alreadyExists) return;
-    
-    let possibleName = sqlStatement;
-    const upperStatement = sqlStatement.toUpperCase();
-    const fromIndex = upperStatement.indexOf(`FROM`);
-    if (fromIndex >= 0) {
-      possibleName = sqlStatement.substring(fromIndex + 4).trim();
-    }
+    if (!alreadyExists) {
+      let possibleName = sqlStatement;
+      const upperStatement = sqlStatement.toUpperCase();
+      const fromIndex = upperStatement.indexOf(`FROM`);
+      if (fromIndex >= 0) {
+        possibleName = sqlStatement.substring(fromIndex + 4).trim();
+      }
 
-    if (upperStatement.includes(`COUNT(`)) {
-      possibleName = `Count ${possibleName}`;
-    }
+      if (upperStatement.includes(`COUNT(`)) {
+        possibleName = `Count ${possibleName}`;
+      }
 
-    this.currentSuggestion = {
-      type: `sqlStatement`,
-      label: possibleName,
-      statement: sqlStatement
-    };
+      this.currentSuggestion = {
+        type: `sqlStatement`,
+        label: possibleName,
+        statement: sqlStatement
+      };
+    }
 
     this.refresh();
   }

--- a/src/views/variables/index.ts
+++ b/src/views/variables/index.ts
@@ -5,8 +5,12 @@ import { SQLExample, Examples, ServiceInfoLabel } from "../examples";
 import { SQLObject } from "../schemaBrowser";
 import ColumnTreeItem from "../types/ColumnTreeItem";
 import { JobManager } from "../../config";
+import Statement from "../../database/statement";
+
+type VariableType = "sql"|"dataarea";
 
 interface Variable {
+  type: VariableType,
   label: string;
   statement: string;
 }
@@ -19,17 +23,32 @@ export class Variables implements TreeDataProvider<any> {
 
   constructor(context: ExtensionContext) {
     context.subscriptions.push(
-      commands.registerCommand(`vscode-db2i.variables.add`, async () => {
-        // TODO: support chosen parameter
-        const userInput = await window.showInputBox({
-          placeHolder: `schema.variableName`,
-          title: `Enter an existing variable name`
-        });
+      commands.registerCommand(`vscode-db2i.variables.add`, async (object?: SQLObject) => {
+        let fetchStatement;
+        
+        if (object && object.type === `variable`) {
+          fetchStatement = Statement.delimName(object.schema) + `.` + Statement.delimName(object.name);
+        }
 
-        if (userInput) {
+        if (!fetchStatement) {
+          // TODO: support chosen parameter
+          fetchStatement = await window.showInputBox({
+            placeHolder: `schema.variableName`,
+            title: `Enter an existing variable name`
+          });
+        }
+
+        if (fetchStatement) {
+          let type: VariableType = `sql`;
+
+          if (fetchStatement.length < 21 && fetchStatement.includes(`/`)) {
+            type = `dataarea`;
+          }
+
           this.variables.push({
-            label: userInput,
-            statement: userInput
+            type,
+            label: fetchStatement,
+            statement: fetchStatement
           });
 
           this.refresh();
@@ -57,12 +76,12 @@ export class Variables implements TreeDataProvider<any> {
     return element;
   }
 
-  async getChildren(element?: VariableTreeItem): Promise<VariableTreeItem[]> {
+  async getChildren(element?: VariableTreeItem): Promise<TreeItem[]> {
     if (this.variables.length === 0) return [];
 
     const sql = this.buildStatement();
 
-    let variableResults: VariableTreeItem[];
+    let variableResults: TreeItem[];
     try {
       const results = await JobManager.runSQL(sql);
 
@@ -72,31 +91,42 @@ export class Variables implements TreeDataProvider<any> {
 
         variableResults = labels.map((label, index) => {
           return new VariableTreeItem(label, {
-            value: firstRow[label]
+            value: String(firstRow[label])
           });
         });
       } else {
         // TODO: welcome page 
       }
     } catch (e) {
-      //TODO: better error handling
-      variableResults = this.variables.map(variable => 
+      variableResults = [new VariableTreeItemError(e.message)];
+      variableResults.push(...this.variables.map(variable => 
         new VariableTreeItem(variable.label, {
-          error: e.message.includes(variable.label) ? e.message : undefined
+          error: true
         })
-      );
+      ));
     }
 
     return variableResults;
   }
 
   private buildStatement(): string {
-    return `select ${this.variables.map(variable => `(${variable.statement}) as "${variable.label}"`).join(`, `)} from sysibm.sysdummy1`;
+    return `select ${this.variables.map(variable => {
+      switch (variable.type) {
+        case `sql`:
+          return `${variable.statement} as "${variable.label}"`;
+        case `dataarea`:
+          const parts = variable.statement.split(`/`);
+          if (parts.length !== 2) {
+            return `'invalid name' as "${variable.label}"`;
+          }
+          return `(select DATA_AREA_VALUE from table(qsys2.data_area_info(data_area_library => '${parts[0].toUpperCase()}', data_area_name => '${parts[1].toUpperCase()}'))) as "${variable.label}"`
+      }
+    }).join(`, `)} from sysibm.sysdummy1`;
   }
 }
 
 class VariableTreeItem extends TreeItem {
-  constructor(variable: string, detail: {error?: string, value?: string}) {
+  constructor(variable: string, detail: {error?: boolean, value?: string}) {
     super(variable, TreeItemCollapsibleState.None);
     this.contextValue = `sqlVarValue`;
 
@@ -115,11 +145,18 @@ class VariableTreeItem extends TreeItem {
 
     if (detail.error) {
       this.iconPath = new ThemeIcon(`error`);
-      this.description = detail.error;
     }
 
     if (!detail.value && !detail.error) {
       this.iconPath = new ThemeIcon(`question`);
     }
+  }
+}
+
+class VariableTreeItemError extends TreeItem {
+  constructor(label: string) {
+    super(label, TreeItemCollapsibleState.None);
+    this.contextValue = `sqlVarValueError`;
+    this.iconPath = new ThemeIcon(`warning`);
   }
 }

--- a/src/views/variables/index.ts
+++ b/src/views/variables/index.ts
@@ -1,0 +1,125 @@
+import { TreeDataProvider, TreeItem, ExtensionContext, commands, workspace, window, TreeItemCollapsibleState, EventEmitter, Event, MarkdownString, ThemeIcon } from "vscode";
+import { getServiceInfo } from "../../database/serviceInfo";
+import { notebookFromStatements } from "../../notebooks/logic/openAsNotebook";
+import { SQLExample, Examples, ServiceInfoLabel } from "../examples";
+import { SQLObject } from "../schemaBrowser";
+import ColumnTreeItem from "../types/ColumnTreeItem";
+import { JobManager } from "../../config";
+
+interface Variable {
+  label: string;
+  statement: string;
+}
+
+export class Variables implements TreeDataProvider<any> {
+  private _onDidChangeTreeData: EventEmitter<TreeItem | undefined | null | void> = new EventEmitter<TreeItem | undefined | null | void>();
+  readonly onDidChangeTreeData: Event<TreeItem | undefined | null | void> = this._onDidChangeTreeData.event;
+
+  private variables: Variable[] = [];
+
+  constructor(context: ExtensionContext) {
+    context.subscriptions.push(
+      commands.registerCommand(`vscode-db2i.variables.add`, async () => {
+        // TODO: support chosen parameter
+        const userInput = await window.showInputBox({
+          placeHolder: `schema.variableName`,
+          title: `Enter an existing variable name`
+        });
+
+        if (userInput) {
+          this.variables.push({
+            label: userInput,
+            statement: userInput
+          });
+
+          this.refresh();
+        }
+      }),
+      commands.registerCommand(`vscode-db2i.variables.remove`, async (variable?: Variable) => {
+        if (variable) {
+          const index = this.variables.findIndex(v => v.label === variable.label);
+
+          if (index !== -1) {
+            this.variables.splice(index, 1);
+            this.refresh();
+          }
+        }
+      }),
+      commands.registerCommand(`vscode-db2i.variables.refresh`, () => this.refresh())
+    );
+  }
+
+  refresh() {
+    this._onDidChangeTreeData.fire();
+  }
+
+  getTreeItem(element: any): TreeItem | Thenable<TreeItem> {
+    return element;
+  }
+
+  async getChildren(element?: VariableTreeItem): Promise<VariableTreeItem[]> {
+    if (this.variables.length === 0) return [];
+
+    const sql = this.buildStatement();
+
+    let variableResults: VariableTreeItem[];
+    try {
+      const results = await JobManager.runSQL(sql);
+
+      if (results.length === 1) {
+        const firstRow = results[0];
+        const labels = Object.keys(firstRow);
+
+        variableResults = labels.map((label, index) => {
+          return new VariableTreeItem(label, {
+            value: firstRow[label]
+          });
+        });
+      } else {
+        // TODO: welcome page 
+      }
+    } catch (e) {
+      //TODO: better error handling
+      variableResults = this.variables.map(variable => 
+        new VariableTreeItem(variable.label, {
+          error: e.message.includes(variable.label) ? e.message : undefined
+        })
+      );
+    }
+
+    return variableResults;
+  }
+
+  private buildStatement(): string {
+    return `select ${this.variables.map(variable => `(${variable.statement}) as "${variable.label}"`).join(`, `)} from sysibm.sysdummy1`;
+  }
+}
+
+class VariableTreeItem extends TreeItem {
+  constructor(variable: string, detail: {error?: string, value?: string}) {
+    super(variable, TreeItemCollapsibleState.None);
+    this.contextValue = `sqlVarValue`;
+
+    if (detail.value !== undefined && detail.value === ``) {
+      detail.value = `-`;
+    }
+
+    if (detail.value) {
+      this.description = detail.value;
+
+      const hover = new MarkdownString();
+      hover.appendCodeblock(detail.value);
+      this.tooltip = hover;
+      this.iconPath = new ThemeIcon(`symbol-variable`);
+    }
+
+    if (detail.error) {
+      this.iconPath = new ThemeIcon(`error`);
+      this.description = detail.error;
+    }
+
+    if (!detail.value && !detail.error) {
+      this.iconPath = new ThemeIcon(`question`);
+    }
+  }
+}

--- a/src/views/variables/index.ts
+++ b/src/views/variables/index.ts
@@ -24,8 +24,8 @@ export class Variables implements TreeDataProvider<any> {
 
   constructor(context: ExtensionContext) {
     context.subscriptions.push(
-      commands.registerCommand(`vscode-db2i.variables.addSuggestion`, () => {
-        if (this.currentSuggestion) {
+      commands.registerCommand(`vscode-db2i.variables.addSuggestion`, (suggestion: Variable) => {
+        if (suggestion) {
           this.variables.push(this.currentSuggestion);
           this.currentSuggestion = undefined;
           this.refresh();
@@ -200,14 +200,15 @@ class VariableSuggestion extends TreeItem {
   constructor(variable: Variable) {
     super(variable.label, TreeItemCollapsibleState.None);
     this.contextValue = `sqlVarSuggestion`;
-    this.description = `Suggested based on executed statements`;
+    this.description = `(click to add)`;
     this.tooltip = new MarkdownString();
     this.tooltip.appendCodeblock(variable.statement, `sql`);
-    this.iconPath = new ThemeIcon(`add`);
+    this.iconPath = new ThemeIcon(`lightbulb`);
 
     this.command = {
       command: `vscode-db2i.variables.addSuggestion`,
       title: `Add suggestion`,
+      arguments: [variable]
     }
   }
 }

--- a/src/views/variables/index.ts
+++ b/src/views/variables/index.ts
@@ -79,7 +79,12 @@ export class Variables implements TreeDataProvider<any> {
         if (!fetchStatement) {
           fetchStatement = await window.showInputBox({
             placeHolder: `schema.variableName`,
-            title: `Enter an existing variable name`
+            title: `Enter an existing variable name`,
+            validateInput: (value) => {
+              if (value.includes(` `)) {
+                return `Variable or data structure path cannot contain spaces.`;
+              }
+            }
           });
         }
 

--- a/src/views/variables/index.ts
+++ b/src/views/variables/index.ts
@@ -68,6 +68,7 @@ export class Variables implements TreeDataProvider<any> {
             statement: fetchStatement
           });
 
+          this.focus();
           this.refresh();
         }
       }),
@@ -88,7 +89,12 @@ export class Variables implements TreeDataProvider<any> {
 
   clear() {
     this.variables = [];
+    this.previousValues = {};
     this.refresh();
+  }
+
+  focus() {
+    return commands.executeCommand(`vscode-db2i.variables.focus`);
   }
 
   refresh() {
@@ -200,7 +206,7 @@ class VariableTreeItem extends TreeItem {
           scheme: VARIABLE_CHANGED_SCHEMA,
           path: `/.`,
         });
-        
+
         hover.appendMarkdown(`\n\n---\n\nValue changed`);
       }
 

--- a/src/views/variables/index.ts
+++ b/src/views/variables/index.ts
@@ -49,6 +49,9 @@ export class Variables implements TreeDataProvider<any> {
   }
 
   private addVariable(variable: Variable) {
+    const alreadyExists = this.variables.some(v => v.statement === variable.statement || v.label === variable.label);
+    if (alreadyExists) return;
+
     this.variables.push(variable);
     this.cacheNewValue(variable.label, NEW_VARIABLE_VALUE);
     this.saveVariables();
@@ -131,6 +134,9 @@ export class Variables implements TreeDataProvider<any> {
   }
 
   setSuggestion(sqlStatement: string) {
+    const alreadyExists = this.variables.some(v => v.statement === sqlStatement);
+    if (alreadyExists) return;
+    
     let possibleName = sqlStatement;
     const upperStatement = sqlStatement.toUpperCase();
     const fromIndex = upperStatement.indexOf(`FROM`);


### PR DESCRIPTION
* Adds new view titled "SQL Variables"
* View can allow the user to see the value of SQL variables, data areas or some SQL statement
* Variables can be added by the user by clicking the variable button in the view header
* Variables can be removed by the user by using the minus button on each variable
* The view is automatically updated when a statement/notebook cell is run
* The view will make a suggestion (marked with a plus) to add a variable to the view after running a statement that returns one row and one column

### How to test

#### Scene 1

1. `create or replace variable yourschema.helloworld varchar(10000) ccsid 1208 default 'scooby';`
2. navigate to `yourschema` in the Schema Browser and expand Variables
3. right click on your new `helloworld` variable and 'Add' it
4. expand the variable view and see the variable and value of it there
5. `set yourschema.helloworld = 'other value';` and see the value automatically change in the view

#### Scene 2

1. run `select count(*) from sometable` (make sure you can insert into this table) and see the result
2. expand the Variables view and see a new node with the plus (+) icon (wording includes 'suggestion' on the node)
3. click on the suggestion node and see the count variable node appear with the count value
4. run `insert into sometime (x, y, z)` and after execution see the count variable increase