### PR TITLE
Add local content assist, improve remote assist

### DIFF
--- a/package.json
+++ b/package.json
@@ -1217,6 +1217,10 @@
       },
       {
         "language": "sql",
+        "path": "snippets/create.code-snippets"
+      },
+      {
+        "language": "sql",
         "path": "snippets/scalars.code-snippets"
       },
       {

--- a/snippets/create.code-snippets
+++ b/snippets/create.code-snippets
@@ -1,0 +1,34 @@
+{
+  "create procedure": {
+    "prefix": "create procedure",
+    "body": [
+      "create or replace procedure ${1:procedure_name}($2)",
+      "  set option usrprf = *user, dynusrprf = *user, commit = *none",
+      "  program type sub",
+      "  modifies sql data",
+      "begin",
+      "  $0",
+      "end;"
+    ],
+    "description": "Simple procedure"
+  },
+  "create function": {
+    "prefix": "create function",
+    "body": [
+      "create or replace function ${1:function_name}($2)",
+      "  returns $3",
+      "begin",
+      "  $0",
+      "  --return value;",
+      "end;"
+    ],
+    "description": "Simple function"
+  },
+  "declare": {
+    "prefix": "declare",
+    "body": [
+      "declare ${1:name} ${2|SMALLINT,INTEGER,INT,BIGINT,DECIMAL,DEC,NUMERIC,FLOAT,REAL,DOUBLE,DECFLOAT,CHAR,CHARACTER,VARCHAR,CLOB,GRAPHIC,VARGRAPHIC,NCHAR,VARYING,NVARCHAR,NCLOB,BLOB,DATE,TIME,TIMESTAMP,XML|}${3} default ${4}${0};",
+    ],
+    "description": "Declare variable"
+  }
+}

--- a/src/language/providers/completionProvider.ts
+++ b/src/language/providers/completionProvider.ts
@@ -508,11 +508,100 @@ async function getCompletionItems(
   return getCompletionItemsForRefs(currentStatement, offset, insideCte ? insideCte.columns : undefined);
 }
 
+const VALID_CREATE_TYPES = [`procedure`, `function`]
+
+function getCompletionItemKindFromSqlType(sqlType: string = `any`) {
+  switch (sqlType.toLowerCase()) {
+    case `schema`:
+      return CompletionItemKind.Folder;
+    case `table`:
+      return CompletionItemKind.File;
+    case `view`:
+      return CompletionItemKind.Interface;
+    case `alias`:
+      return CompletionItemKind.Reference;
+    case `procedure`:
+      return CompletionItemKind.Method;
+    case `function`:
+      return CompletionItemKind.Function;
+    case `cursor`:
+      return CompletionItemKind.File;
+    default:
+      return CompletionItemKind.Variable;
+  }
+}
+
+/**
+ * Returns completion items based solely on an SQL document
+ * @param sqlDoc
+ */
+function getLocalDefs(sqlDoc: Document, offset: number) {
+  const groups = sqlDoc.getStatementGroups();
+
+  let items: CompletionItem[] = [];
+
+
+  groups.forEach((group) => {
+    const groupStatements = group.statements;
+    const statement = group.statements[0];
+    const inGroupRange = offset >= group.range.start && offset <= group.range.end;
+
+    if (groupStatements.length === 1) {
+      switch (statement.type) {
+        case StatementType.With:
+          if (inGroupRange) {
+            const ctes = statement.getCTEReferences();
+            items.push(...ctes.map(cte => createCompletionItem(cte.name, CompletionItemKind.Interface)));
+          }
+          break;
+
+        case StatementType.Create:
+          const [currentCreate] = statement.getObjectReferences();
+          if (currentCreate) {
+            items.push(createCompletionItem(currentCreate.object.schema ? `${currentCreate.object.schema}.${currentCreate.object.name}` : currentCreate.object.name, getCompletionItemKindFromSqlType(currentCreate.createType), `Local ${currentCreate.createType || `creation`}`));
+          }
+          break;
+      }
+
+    } else if (groupStatements.length > 1) {
+      // Usually means statements that have a body
+
+      // We only care about create statements when there is a body
+      if (statement.type === StatementType.Create) {
+        const [groupDef] = statement.getObjectReferences();
+        
+        // We only care about certain create types
+        if (groupDef) {
+          const currentType = groupDef.createType.toLowerCase();
+          if (groupDef.createType && VALID_CREATE_TYPES.includes(currentType) && groupDef.object.name) {
+            items.push(createCompletionItem(groupDef.object.schema ? `${groupDef.object.schema}.${groupDef.object.name}` : groupDef.object.name, getCompletionItemKindFromSqlType(groupDef.createType), `Local ${currentType}`));
+          }
+        }
+
+        // We only want to add local variables if we're inside the current group
+        if (inGroupRange) {
+          for (let i = 1; i < groupStatements.length; i++) {
+            const subStatement = groupStatements[i];
+            if (subStatement.type === StatementType.Declare) {
+              const [def] = subStatement.getObjectReferences();
+              if (def) {
+                items.push(createCompletionItem(def.object.name, CompletionItemKind.Variable, def.createType));
+              }
+            }
+          }
+        }
+      }
+    }
+  });
+
+  return items;
+}
+
 export const completionProvider = languages.registerCompletionItemProvider(
   `sql`,
   {
     async provideCompletionItems(document, position, token, context) {
-      if (ServerComponent.isInstalled() && isEnabled()) {
+      if (isEnabled()) {
         const trigger = context.triggerCharacter;
         const content = document.getText();
         const offset = document.offsetAt(position);
@@ -520,9 +609,17 @@ export const completionProvider = languages.registerCompletionItemProvider(
         const sqlDoc = new Document(content);
         const currentStatement = sqlDoc.getStatementByOffset(offset);
 
-        if (currentStatement) {
-          return getCompletionItems(trigger, currentStatement, offset);
+        const allItems: CompletionItem[] = [];
+
+        if (trigger !== `.`) {
+          allItems.push(...getLocalDefs(sqlDoc, offset))
         }
+
+        if (ServerComponent.isInstalled() && currentStatement) {
+          allItems.push(...await getCompletionItems(trigger, currentStatement, offset))
+        }
+
+        return allItems;
       }
     },
   },

--- a/src/language/providers/completionProvider.ts
+++ b/src/language/providers/completionProvider.ts
@@ -16,6 +16,7 @@ import { ServerComponent } from "../../connection/serverComponent";
 import { env } from "process";
 import { prepareParamType, createCompletionItem, getParmAttributes, completionItemCache } from "./completion";
 import { isCallableType, getCallableParameters } from "./callable";
+import { variable } from "sql-formatter/lib/src/lexer/regexFactory";
 
 export interface CompletionType {
   order: string;
@@ -48,6 +49,12 @@ const completionTypes: { [index: string]: CompletionType } = {
     label: `function`,
     type: `functions`, 
     icon: CompletionItemKind.Method
+  },
+  variables: {
+    order: `f`,
+    label: `variable`,
+    type: `variables`,
+    icon: CompletionItemKind.Variable,
   }
 };
 
@@ -157,7 +164,7 @@ async function getObjectCompletions(
         createCompletionItem(
           Statement.prettyName(table.name),
           value.icon,
-          `Type: ${value.label}`,
+          value.label,
           `Schema: ${table.schema}`,
           value.order
         )
@@ -185,7 +192,7 @@ async function getCompletionItemsForSchema(
       createCompletionItem(
         Statement.prettyName(item.name),
         CompletionItemKind.Method,
-        `Type: Procedure`,
+        `Procedure`,
         `Schema: ${item.schema}`
       )
     );
@@ -319,7 +326,7 @@ async function getCachedSchemas() {
     createCompletionItem(
       Statement.prettyName(schema.name),
       CompletionItemKind.Module,
-      `Type: Schema`,
+      `Schema`,
       `Text: ${schema.text}`
     )
   );

--- a/src/language/providers/completionProvider.ts
+++ b/src/language/providers/completionProvider.ts
@@ -585,8 +585,13 @@ function getLocalDefs(sqlDoc: Document, offset: number) {
           }
         }
 
-        // We only want to add local variables if we're inside the current group
+        // When our cursor is in the current statement..
         if (inGroupRange) {
+          // Show parameters to the routine
+          const localParams = statement.getRoutineParameters();
+          items.push(...localParams.map(param => createCompletionItem(param.alias, CompletionItemKind.Property, param.createType)));
+
+          // Show all the local definitions
           for (let i = 1; i < groupStatements.length; i++) {
             const subStatement = groupStatements[i];
             if (subStatement.type === StatementType.Declare) {

--- a/src/language/providers/parameterProvider.ts
+++ b/src/language/providers/parameterProvider.ts
@@ -5,65 +5,69 @@ import { getCachedSignatures, getCallableParameters, getPositionData, isCallable
 import { getParmAttributes, prepareParamType } from "./completion";
 import { CallableType } from "../../database/callable";
 import { StatementType } from "../sql/types";
+import { ServerComponent } from "../../connection/serverComponent";
 
 export const signatureProvider = languages.registerSignatureHelpProvider({ language: `sql` }, {
   async provideSignatureHelp(document, position, token, context) {
     const content = document.getText();
     const offset = document.offsetAt(position);
 
-    const sqlDoc = new Document(content);
-    const currentStatement = sqlDoc.getStatementByOffset(offset);
+    if (ServerComponent.isInstalled()) {
 
-    if (currentStatement) {
-      const routineType: CallableType = currentStatement.type === StatementType.Call ? `PROCEDURE` : `FUNCTION`;
-      const callableRef = currentStatement.getCallableDetail(offset, true);
-      // TODO: check the function actually exists before returning
-      if (callableRef) {
-        const isValid = await isCallableType(callableRef.parentRef, routineType);
-        if (isValid) {
-          let signatures = getCachedSignatures(callableRef);
-          if (signatures) {
-            const help = new SignatureHelp();
+      const sqlDoc = new Document(content);
+      const currentStatement = sqlDoc.getStatementByOffset(offset);
 
-            const { firstNamedParameter, currentParm, currentCount } = getPositionData(callableRef, offset);
+      if (currentStatement) {
+        const routineType: CallableType = currentStatement.type === StatementType.Call ? `PROCEDURE` : `FUNCTION`;
+        const callableRef = currentStatement.getCallableDetail(offset, true);
+        // TODO: check the function actually exists before returning
+        if (callableRef) {
+          const isValid = await isCallableType(callableRef.parentRef, routineType);
+          if (isValid) {
+            let signatures = getCachedSignatures(callableRef);
+            if (signatures) {
+              const help = new SignatureHelp();
 
-            if (firstNamedParameter === 0) {
-              return;
+              const { firstNamedParameter, currentParm, currentCount } = getPositionData(callableRef, offset);
+
+              if (firstNamedParameter === 0) {
+                return;
+              }
+
+              help.activeParameter = currentParm;
+              help.signatures = [];
+
+              // Remove any signatures that have more parameters than the current count and sort them
+              signatures = signatures.filter((s) => s.parms.length >= currentCount).sort((a, b) => a.parms.length - b.parms.length);
+              help.activeSignature = signatures.findIndex((signature) => currentCount <= signature.parms.length);
+
+              for (const signature of signatures) {
+                const parms = signature.parms;
+
+                const validParms = parms.filter((parm, i) => parm.DEFAULT === null && parm.PARAMETER_MODE !== `OUT` && (firstNamedParameter === undefined || i < firstNamedParameter));
+
+                const signatureInfo = new SignatureInformation(
+                  (callableRef.parentRef.object.schema ? Statement.prettyName(callableRef.parentRef.object.schema) + `.` : ``) + Statement.prettyName(callableRef.parentRef.object.name) +
+                  `(` + validParms.map((parm, i) => Statement.prettyName(parm.PARAMETER_NAME || `PARM${i}`)).join(`, `) + (parms.length > validParms.length ? `, ...` : ``) + `)`);
+
+                signatureInfo.parameters = validParms.map((parm, i) => {
+                  const mdString = new MarkdownString(
+                    [
+                      `\`${parm.PARAMETER_MODE} ${prepareParamType(parm).toLowerCase()}\``,
+                      parm.LONG_COMMENT
+                    ].join(`\n\n`),
+                  )
+                  return new ParameterInformation(
+                    Statement.prettyName(parm.PARAMETER_NAME || `PARM${i}`),
+                    mdString
+                  );
+                });
+
+                help.signatures.push(signatureInfo);
+              }
+
+              return help;
             }
-
-            help.activeParameter = currentParm;
-            help.signatures = [];
-
-            // Remove any signatures that have more parameters than the current count and sort them
-            signatures = signatures.filter((s) => s.parms.length >= currentCount).sort((a, b) => a.parms.length - b.parms.length);
-            help.activeSignature = signatures.findIndex((signature) => currentCount <= signature.parms.length);
-
-            for (const signature of signatures) {
-              const parms = signature.parms;
-
-              const validParms = parms.filter((parm, i) => parm.DEFAULT === null && parm.PARAMETER_MODE !== `OUT` && (firstNamedParameter === undefined || i < firstNamedParameter));
-
-              const signatureInfo = new SignatureInformation(
-                (callableRef.parentRef.object.schema ? Statement.prettyName(callableRef.parentRef.object.schema) + `.` : ``) + Statement.prettyName(callableRef.parentRef.object.name) +
-                `(` + validParms.map((parm, i) => Statement.prettyName(parm.PARAMETER_NAME || `PARM${i}`)).join(`, `) + (parms.length > validParms.length ? `, ...` : ``) + `)`);
-
-              signatureInfo.parameters = validParms.map((parm, i) => {
-                const mdString = new MarkdownString(
-                  [
-                    `\`${parm.PARAMETER_MODE} ${prepareParamType(parm).toLowerCase()}\``,
-                    parm.LONG_COMMENT
-                  ].join(`\n\n`),
-                )
-                return new ParameterInformation(
-                  Statement.prettyName(parm.PARAMETER_NAME || `PARM${i}`),
-                  mdString
-                );
-              });
-
-              help.signatures.push(signatureInfo);
-            }
-
-            return help;
           }
         }
       }

--- a/src/language/sql/statement.ts
+++ b/src/language/sql/statement.ts
@@ -424,12 +424,13 @@ export default class Statement {
 					} else {
 						let defaultIndex = this.tokens.findIndex(t => tokenIs(t, `keyword`, `DEFAULT`));
 
-						def.createType = this.tokens
+						const valueTokens = this.tokens
 							.slice(
 								2, 
 								defaultIndex >= 0 ? defaultIndex : undefined
-							)
-							.map(t => t.value).join(``);
+							);
+
+						def.createType = Statement.formatSimpleTokens(valueTokens);
 					}
 
 					doAdd(def);
@@ -682,4 +683,34 @@ export default class Statement {
     }
     return tokens;
   }
+
+	private static formatSimpleTokens(tokens: Token[]) {
+		let outString = ``;
+		for (let i = 0; i < tokens.length; i++) {
+			const cT = tokens[i];
+			const nT = tokens[i+1];
+			const pT = tokens[i-1];
+	
+			switch (cT.type) {
+				case `openbracket`:
+					outString += cT.value;
+					break;
+				case `closebracket`:
+					if (nT && nT.type === cT.type) {
+						outString += cT.value
+					} else {
+						outString += `${cT.value} `;
+					}
+					break;
+				default:
+					if (nT && (![`closebracket`, `openbracket`, `comma`].includes(nT.type))) {
+						outString += `${cT.value} `;
+					} else {
+						outString += cT.value;
+					}
+					break;
+			}
+		}
+		return outString.trimEnd();
+	}
 }

--- a/src/language/sql/statement.ts
+++ b/src/language/sql/statement.ts
@@ -262,7 +262,7 @@ export default class Statement {
 			let currentChunk: Token[] = [];
 
 			for (const token of inTokens) {
-				if (tokenIs(token, `keyword`, type)) {
+				if (tokenIs(token, type)) {
 					if (currentChunk.length > 0) {
 						chunks.push(currentChunk);
 						currentChunk = [];
@@ -758,15 +758,19 @@ export default class Statement {
 			switch (cT.type) {
 				case `block`:
 					outString += `(${Statement.formatSimpleTokens(cT.block!)})`;
+
+					if (nT && nT.type !== `closebracket`) {
+						outString += ` `;
+					}
 					break;
 				case `openbracket`:
 					outString += cT.value;
 					break;
 				case `closebracket`:
-					if (nT && nT.type === cT.type) {
-						outString += cT.value
-					} else {
-						outString += `${cT.value} `;
+					outString += cT.value
+					
+					if (nT && nT.type !== cT.type) {
+						outString += ` `
 					}
 					break;
 				default:

--- a/src/language/sql/statement.ts
+++ b/src/language/sql/statement.ts
@@ -377,6 +377,12 @@ export default class Statement {
 							}
 							break;
 
+						case `VARIABLE`:
+							if (postName) {
+								object.createType = Statement.formatSimpleTokens(this.tokens.slice(postName));
+							}
+							break;
+
 						case `VIEW`:
 						case `TABLE`:
 							const asKeyword = this.tokens.findIndex(token => tokenIs(token, `keyword`, `AS`));

--- a/src/language/sql/tests/statements.test.ts
+++ b/src/language/sql/tests/statements.test.ts
@@ -805,6 +805,10 @@ describe(`Object references`, () => {
     const [group] = groups;
 
     const createStatement = group.statements[0];
+
+    const parms = createStatement.getRoutineParameters();
+    expect(parms.length).toBe(0);
+
     const refsA = createStatement.getObjectReferences();
     expect(createStatement.type).toBe(StatementType.Create);
     expect(refsA.length).toBe(1);
@@ -844,6 +848,12 @@ describe(`Object references`, () => {
     const createStatement = groups[0].statements[0];
 
     expect(createStatement.type).toBe(StatementType.Create);
+
+    const parms = createStatement.getRoutineParameters();
+    expect(parms.length).toBe(1);
+    expect(parms[0].alias).toBe(`base`);
+    expect(parms[0].createType).toBe(`IN CHAR(100)`);
+
     const refs = createStatement.getObjectReferences();
     expect(refs.length).toBe(2);
 
@@ -963,6 +973,11 @@ describe(`PL body tests`, () => {
     expect(medianResultSetProc.type).toBe(StatementType.Create);
     expect(medianResultSetProc.isBlockOpener()).toBe(true);
 
+    const parms = medianResultSetProc.getRoutineParameters();
+    expect(parms.length).toBe(1);
+    expect(parms[0].alias).toBe(`medianSalary`);
+    expect(parms[0].createType).toBe(`OUT DECIMAL(7, 2)`);
+
     const numRecordsDeclare = statements[1];
     expect(numRecordsDeclare.type).toBe(StatementType.Declare);
 
@@ -1019,10 +1034,14 @@ describe(`PL body tests`, () => {
     expect(medianResultSetProc.type).toBe(StatementType.Create);
     expect(medianResultSetProc.isBlockOpener()).toBe(true);
 
+    const parms = medianResultSetProc.getRoutineParameters();
+    expect(parms.length).toBe(1);
+    expect(parms[0].alias).toBe(`medianSalary`);
+    expect(parms[0].createType).toBe(`OUT DECIMAL(7, 2)`);
 
     const parameterTokens = medianResultSetProc.getBlockAt(46);
     expect(parameterTokens.length).toBeGreaterThan(0);
-    expect(parameterTokens.map(t => t.type).join()).toBe([`word`, `word`, `word`, `openbracket`, `word`, `comma`, `word`, `closebracket`].join());
+    expect(parameterTokens.map(t => t.type).join()).toBe([`parmType`, `word`, `word`, `openbracket`, `word`, `comma`, `word`, `closebracket`].join());
 
     const numRecordsDeclare = statements[1];
     expect(numRecordsDeclare.type).toBe(StatementType.Declare);

--- a/src/language/sql/tests/statements.test.ts
+++ b/src/language/sql/tests/statements.test.ts
@@ -818,7 +818,7 @@ describe(`Object references`, () => {
     expect(declareStatement.type).toBe(StatementType.Declare);
     const refsB = declareStatement.getObjectReferences();
     expect(refsB.length).toBe(1);
-    expect(refsB[0].createType).toBe(`decimal(9,2)`);
+    expect(refsB[0].createType).toBe(`decimal(9, 2)`);
     expect(refsB[0].object.name).toBe(`total`);
 
     // Let's check we get the table back for this select
@@ -855,7 +855,22 @@ describe(`Object references`, () => {
     expect(refs[1].createType).toBe(`external`);
     expect(refs[1].object.system).toBe(`PROGRAM`);
     expect(refs[1].object.schema).toBe(`LIB`);
-  })
+  });
+
+  test(`DECLARE VARIABLE`, () => {
+    const document = new Document(`declare watsonx_response   Varchar(10000) CCSID 1208;`);
+    const groups = document.getStatementGroups();
+
+    expect(groups.length).toBe(1);
+    const createStatement = groups[0].statements[0];
+
+    expect(createStatement.type).toBe(StatementType.Declare);
+    const refs = createStatement.getObjectReferences();
+    expect(refs.length).toBe(1);
+
+    expect(refs[0].object.name).toBe(`watsonx_response`);
+    expect(refs[0].createType).toBe(`Varchar(10000) CCSID 1208`);
+  });
 });
 
 describe(`Offset reference tests`, () => {

--- a/src/language/sql/tests/statements.test.ts
+++ b/src/language/sql/tests/statements.test.ts
@@ -871,6 +871,23 @@ describe(`Object references`, () => {
     expect(refs[0].object.name).toBe(`watsonx_response`);
     expect(refs[0].createType).toBe(`Varchar(10000) CCSID 1208`);
   });
+
+  test(`CREATE OR REPLACE VARIABLE`, () => {
+    const document = new Document(`create or replace variable watsonx.apiVersion varchar(10) ccsid 1208 default '2023-07-07';`);
+
+    const groups = document.getStatementGroups();
+
+    expect(groups.length).toBe(1);
+    const createStatement = groups[0].statements[0];
+
+    expect(createStatement.type).toBe(StatementType.Create);
+    const refs = createStatement.getObjectReferences();
+    expect(refs.length).toBe(1);
+
+    expect(refs[0].object.schema).toBe(`watsonx`);
+    expect(refs[0].object.name).toBe(`apiVersion`);
+    expect(refs[0].createType).toBe(`varchar(10) ccsid 1208 default '2023-07-07'`);
+  });
 });
 
 describe(`Offset reference tests`, () => {

--- a/src/language/sql/tokens.ts
+++ b/src/language/sql/tokens.ts
@@ -27,6 +27,11 @@ interface TokenState {
 export default class SQLTokeniser {
   matchers: Matcher[] = [
     {
+      name: `PROCEDURE_PARM_TYPE`,
+      match: [{ type: `word`, match: (value: string) => {return [`IN`, `OUT`, `INOUT`].includes(value.toUpperCase())}}],
+      becomes: `parmType`,
+    },
+    {
       name: `STATEMENTTYPE`,
       match: [{ type: `word`, match: (value: string) => {
         return [`CREATE`, `ALTER`, `SELECT`, `WITH`, `INSERT`, `UPDATE`, `DELETE`, `DROP`, `CALL`, `DECLARE`].includes(value.toUpperCase());


### PR DESCRIPTION
* Adds support to content assist to show location definitions in source without reaching out to the server
   * local `declare` variables and cursors
   * procedure and function parameters
* Improvements to supporting `declare` and `create variable`
* Fix to parameter provider crashing when not connected to a system
* Show variables in schemas for regular content assist

![image](https://github.com/user-attachments/assets/776e0ad4-9d97-4d1c-8b34-e3efa51637fe)

![image](https://github.com/user-attachments/assets/aefddaa3-a923-4e19-9a25-fe26b26219a4)

![image](https://github.com/user-attachments/assets/28635701-b82c-48fa-8b26-f8e21aef2f6b)

### How to test

* Open any SQL file where you have a few create statements, and prompt for the content assist, or
* Clone [this repo](https://github.com/ThePrez/WatsonX-SDK-Db2-IBMi) and try it out on some of the local sources