### PR TITLE
Update vscode-ibmi event listener and test runner

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vscode-db2i",
-  "version": "1.1.4",
+  "version": "1.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "vscode-db2i",
-      "version": "1.1.4",
+      "version": "1.2.0",
       "dependencies": {
         "chart.js": "^4.4.2",
         "csv": "^6.1.3",
@@ -17,7 +17,7 @@
         "sql-formatter": "^14.0.0"
       },
       "devDependencies": {
-        "@halcyontech/vscode-ibmi-types": "^2.0.0",
+        "@halcyontech/vscode-ibmi-types": "^2.12.1",
         "@types/glob": "^7.1.3",
         "@types/node": "14.x",
         "@types/vscode": "^1.70.0",
@@ -523,9 +523,9 @@
       }
     },
     "node_modules/@halcyontech/vscode-ibmi-types": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@halcyontech/vscode-ibmi-types/-/vscode-ibmi-types-2.1.0.tgz",
-      "integrity": "sha512-vmz3CFHoJT8m0iQhghnSY9LC/BIKDP0Dr/CcOVRUS16uVtWP82Sf+lICV4XeIcak4f3FRklDCcIbgkywwv/9lQ==",
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/@halcyontech/vscode-ibmi-types/-/vscode-ibmi-types-2.12.1.tgz",
+      "integrity": "sha512-28OUrucjb98bo28KrEbw0xMr00BZ9RWLbXhAW4kapcZ7CNhrOIIZg/LlP+LjVzfJ97i+XyhdCF1es2+2oFMdXg==",
       "dev": true
     },
     "node_modules/@humanwhocodes/config-array": {
@@ -3262,12 +3262,12 @@
       "dev": true
     },
     "node_modules/micromatch": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
-      "integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
       "dev": true,
       "dependencies": {
-        "braces": "^3.0.2",
+        "braces": "^3.0.3",
         "picomatch": "^2.3.1"
       },
       "engines": {
@@ -5967,9 +5967,9 @@
       }
     },
     "@halcyontech/vscode-ibmi-types": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@halcyontech/vscode-ibmi-types/-/vscode-ibmi-types-2.1.0.tgz",
-      "integrity": "sha512-vmz3CFHoJT8m0iQhghnSY9LC/BIKDP0Dr/CcOVRUS16uVtWP82Sf+lICV4XeIcak4f3FRklDCcIbgkywwv/9lQ==",
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/@halcyontech/vscode-ibmi-types/-/vscode-ibmi-types-2.12.1.tgz",
+      "integrity": "sha512-28OUrucjb98bo28KrEbw0xMr00BZ9RWLbXhAW4kapcZ7CNhrOIIZg/LlP+LjVzfJ97i+XyhdCF1es2+2oFMdXg==",
       "dev": true
     },
     "@humanwhocodes/config-array": {
@@ -8111,12 +8111,12 @@
       "dev": true
     },
     "micromatch": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
-      "integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
       "dev": true,
       "requires": {
-        "braces": "^3.0.2",
+        "braces": "^3.0.3",
         "picomatch": "^2.3.1"
       }
     },

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "typings": "npx -p typescript tsc ./src/extension.ts --declaration --allowJs --emitDeclarationOnly --outDir types --esModuleInterop -t es2019 --moduleResolution node"
   },
   "devDependencies": {
-    "@halcyontech/vscode-ibmi-types": "^2.0.0",
+    "@halcyontech/vscode-ibmi-types": "^2.12.1",
     "@types/glob": "^7.1.3",
     "@types/node": "14.x",
     "@types/vscode": "^1.70.0",

--- a/src/config.ts
+++ b/src/config.ts
@@ -69,7 +69,7 @@ export async function onConnectOrServerInstall(): Promise<boolean> {
 export function initConfig(context: ExtensionContext) {
   Config = new ConnectionStorage(context);
 
-  getInstance().onEvent(`disconnected`, async () => {
+  getInstance().subscribe(context, `disconnected`, `db2i-disconnect`, async () => {
     JobManagerView.setVisible(false);
     JobManager.endAll();
     updateStatusBar();

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -11,7 +11,7 @@ import { JobManager, onConnectOrServerInstall, initConfig } from "./config";
 import { queryHistory } from "./views/queryHistoryView";
 import { ExampleBrowser } from "./views/examples/exampleBrowser";
 import { languageInit } from "./language";
-import { initialise } from "./testing";
+import { initialiseTestSuite } from "./testing";
 import { JobManagerView } from "./views/jobManager/jobManagerView";
 import { ServerComponent } from "./connection/serverComponent";
 import { SQLJobManager } from "./connection/manager";
@@ -75,20 +75,26 @@ export function activate(context: vscode.ExtensionContext): Db2i {
   initConfig(context);
 
   console.log(`Developer environment: ${process.env.DEV}`);
-  if (process.env.DEV) {
+  const devMode = process.env.DEV !== undefined;
+  let runTests: Function|undefined;
+  if (devMode) {
     // Run tests if not in production build
-    initialise(context);
+    runTests = initialiseTestSuite(context);
   }
 
   const instance = getInstance();
 
-  instance.onEvent(`connected`, () => {
+  instance.subscribe(context, `connected`, `db2i-connected`, () => {
     selfCodesView.setRefreshEnabled(false);
     selfCodesView.setJobOnly(false);
     // Refresh the examples when we have it, so we only display certain examples
     onConnectOrServerInstall().then(() => {
       exampleBrowser.refresh();
-      selfCodesView.setRefreshEnabled(Configuration.get(`jobSelfViewAutoRefresh`) || false)
+      selfCodesView.setRefreshEnabled(Configuration.get(`jobSelfViewAutoRefresh`) || false);
+
+      if (devMode && runTests) {
+        runTests();
+      }
     });
   });
 

--- a/src/testing/index.ts
+++ b/src/testing/index.ts
@@ -28,14 +28,13 @@ export interface TestCase {
   test: () => Promise<void>
 }
 
-let testSuitesTreeProvider : TestSuitesTreeProvider;
-export function initialise(context: vscode.ExtensionContext) {
+let testSuitesTreeProvider: TestSuitesTreeProvider;
+export function initialiseTestSuite(context: vscode.ExtensionContext) {
   if (env.testing === `true`) {
     const instance = getInstance();
 
     vscode.commands.executeCommand(`setContext`, `vscode-db2i:testing`, true);
-    instance.onEvent(`connected`, runTests);
-    instance.onEvent(`disconnected`, resetTests);
+    instance.subscribe(context, `disconnected`, `db2i-resetTests`, resetTests);
 
     testSuitesTreeProvider = new TestSuitesTreeProvider(suites);
 
@@ -55,6 +54,8 @@ export function initialise(context: vscode.ExtensionContext) {
         }
       })
     );
+
+    return runTests;
   }
 }
 

--- a/src/views/schemaBrowser/index.ts
+++ b/src/views/schemaBrowser/index.ts
@@ -374,7 +374,7 @@ export default class schemaBrowser {
       })
     )
 
-    getInstance().onEvent(`connected`, () => this.clearCacheAndRefresh());
+    getInstance().subscribe(context, `connected`, `db2i-clearCacheAndRefresh`, () => this.clearCacheAndRefresh());
   }
 
   clearCacheAndRefresh() {


### PR DESCRIPTION
* Replace deprecated `onEvent` listener in place of `subscribe`
* Fix bug where tests were starting before server component was installed.