### PR TITLE
Ability to run a statement via URI

### DIFF
--- a/package.json
+++ b/package.json
@@ -318,6 +318,11 @@
         "category": "Db2 for i"
       },
       {
+        "command": "vscode-db2i.getStatementUri",
+        "title": "Get shared statement URI",
+        "category": "Db2 for i"
+      },
+      {
         "command": "vscode-db2i.refreshSchemaBrowser",
         "title": "Refresh Schema Browser",
         "category": "Db2 for i",
@@ -667,19 +672,11 @@
       }
     ],
     "menus": {
-      "editor/context": [
+      "commandPalette": [
         {
-          "command": "vscode-db2i.json.pasteGenerator",
-          "group": "sql@1",
+          "command": "vscode-db2i.getStatementUri",
           "when": "editorLangId == sql"
         },
-        {
-          "command": "vscode-db2i.json.pasteParser",
-          "group": "sql@2",
-          "when": "editorLangId == sql"
-        }
-      ],
-      "commandPalette": [
         {
           "command": "vscode-db2i.setSchemaFilter",
           "when": "never"
@@ -755,6 +752,18 @@
         {
           "command": "vscode-db2i.notebook.fromSqlUri",
           "when": "never"
+        }
+      ],
+      "editor/context": [
+        {
+          "command": "vscode-db2i.json.pasteGenerator",
+          "group": "sql@1",
+          "when": "editorLangId == sql"
+        },
+        {
+          "command": "vscode-db2i.json.pasteParser",
+          "group": "sql@2",
+          "when": "editorLangId == sql"
         }
       ],
       "view/title": [

--- a/package.json
+++ b/package.json
@@ -319,7 +319,7 @@
       },
       {
         "command": "vscode-db2i.getStatementUri",
-        "title": "Get shared statement URI",
+        "title": "Copy sharable statement URI",
         "category": "Db2 for i"
       },
       {
@@ -755,6 +755,11 @@
         }
       ],
       "editor/context": [
+        {
+          "command": "vscode-db2i.getStatementUri",
+          "group": "sql@0",
+          "when": "editorLangId == sql"
+        },
         {
           "command": "vscode-db2i.json.pasteGenerator",
           "group": "sql@1",

--- a/src/contributes.json
+++ b/src/contributes.json
@@ -94,9 +94,20 @@
         "command": "vscode-db2i.json.pasteParser",
         "title": "Generate JSON SQL parser",
         "category": "Db2 for i"
+      },
+      {
+        "command": "vscode-db2i.getStatementUri",
+        "title": "Get shared statement URI",
+        "category": "Db2 for i"
       }
     ],
     "menus": {
+      "commandPalette": [
+        {
+          "command": "vscode-db2i.getStatementUri",
+          "when": "editorLangId == sql"
+        }
+      ],
       "editor/context": [
         {
           "command": "vscode-db2i.json.pasteGenerator",

--- a/src/contributes.json
+++ b/src/contributes.json
@@ -97,7 +97,7 @@
       },
       {
         "command": "vscode-db2i.getStatementUri",
-        "title": "Get shared statement URI",
+        "title": "Copy sharable statement URI",
         "category": "Db2 for i"
       }
     ],
@@ -109,6 +109,11 @@
         }
       ],
       "editor/context": [
+        {
+          "command": "vscode-db2i.getStatementUri",
+          "group": "sql@0",
+          "when": "editorLangId == sql"
+        },
         {
           "command": "vscode-db2i.json.pasteGenerator",
           "group": "sql@1",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -20,6 +20,7 @@ import { notebookInit } from "./notebooks/IBMiSerializer";
 import { SelfTreeDecorationProvider, selfCodesResultsView } from "./views/jobManager/selfCodes/selfCodesResultsView";
 import Configuration from "./configuration";
 import { JDBCOptions } from "@ibm/mapepire-js/dist/src/types";
+import { Db2iUriHandler } from "./uriHandler";
 
 export interface Db2i {
   sqlJobManager: SQLJobManager,
@@ -66,7 +67,8 @@ export function activate(context: vscode.ExtensionContext): Db2i {
     ),
     vscode.window.registerFileDecorationProvider(
       new SelfTreeDecorationProvider()
-    ) 
+    ),
+    vscode.window.registerUriHandler(new Db2iUriHandler())
   );
 
   JSONServices.initialise(context);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -20,7 +20,7 @@ import { notebookInit } from "./notebooks/IBMiSerializer";
 import { SelfTreeDecorationProvider, selfCodesResultsView } from "./views/jobManager/selfCodes/selfCodesResultsView";
 import Configuration from "./configuration";
 import { JDBCOptions } from "@ibm/mapepire-js/dist/src/types";
-import { Db2iUriHandler } from "./uriHandler";
+import { Db2iUriHandler, getStatementUri } from "./uriHandler";
 
 export interface Db2i {
   sqlJobManager: SQLJobManager,
@@ -68,7 +68,8 @@ export function activate(context: vscode.ExtensionContext): Db2i {
     vscode.window.registerFileDecorationProvider(
       new SelfTreeDecorationProvider()
     ),
-    vscode.window.registerUriHandler(new Db2iUriHandler())
+    vscode.window.registerUriHandler(new Db2iUriHandler()),
+    getStatementUri
   );
 
   JSONServices.initialise(context);

--- a/src/uriHandler.ts
+++ b/src/uriHandler.ts
@@ -1,4 +1,4 @@
-import { commands, env, Uri, UriHandler, window, workspace } from "vscode";
+import { commands, env, Selection, Uri, UriHandler, window, workspace } from "vscode";
 import querystring from "querystring";
 import Document from "./language/sql/document";
 import { ServerComponent } from "./connection/serverComponent";
@@ -57,7 +57,9 @@ export const getStatementUri = commands.registerCommand(`vscode-db2i.getStatemen
     const currentStmt = sqlDocument.getGroupByOffset(cursor);
 
     if (currentStmt) {
-      const uri = `vscode://halcyontechltd.vscode-db2i/sql?content=${encodeURIComponent(sqlDocument.content)}`;
+      const stmtContent = content.substring(currentStmt.range.start, currentStmt.range.end);
+      editor.selection = new Selection(editor.document.positionAt(currentStmt.range.start), editor.document.positionAt(currentStmt.range.end));
+      const uri = `vscode://halcyontechltd.vscode-db2i/sql?content=${encodeURIComponent(stmtContent)}`;
 
       env.clipboard.writeText(uri);
       window.showInformationMessage(`Statement URI copied to clipboard.`);

--- a/src/uriHandler.ts
+++ b/src/uriHandler.ts
@@ -1,0 +1,66 @@
+import { commands, env, Uri, UriHandler, window, workspace } from "vscode";
+import querystring from "querystring";
+import Document from "./language/sql/document";
+import { ServerComponent } from "./connection/serverComponent";
+import { remoteAssistIsEnabled } from "./language/providers/available";
+
+export class Db2iUriHandler implements UriHandler {
+  handleUri(uri: Uri) {
+    const path = uri.path;
+
+    switch (path) {
+      case '/sql':
+        const queryData = querystring.parse(uri.query);
+        const content = String(queryData.content).trim();
+
+        if (content) {
+          const asLower = content.toLowerCase();
+          const isValid = asLower.startsWith(`select `) || asLower.startsWith(`with `);
+
+          if (isValid) {
+            const run = queryData.run === `true`;
+
+            if (run) {
+              if (remoteAssistIsEnabled()) {
+                commands.executeCommand(`vscode-db2i.runEditorStatement`, {
+                  content,
+                  qualifier: `statement`,
+                  open: true,
+                });
+              } else {
+                window.showErrorMessage(`You must be connected to a system to run a statement.`);
+              }
+            } else {
+              workspace.openTextDocument({ language: `sql`, content }).then(textDoc => {
+                window.showTextDocument(textDoc);
+              });
+            }
+          } else {
+            window.showErrorMessage(`Only SELECT or WITH statements are supported.`);
+          }
+        }
+
+        break;
+    }
+  }
+}
+
+export const getStatementUri = commands.registerCommand(`vscode-db2i.getStatementUri`, async () => {
+  const editor = window.activeTextEditor;
+
+  if (editor) {
+    const content = editor.document.getText();
+
+    const sqlDocument = new Document(content);
+    const cursor = editor.document.offsetAt(editor.selection.active);
+
+    const currentStmt = sqlDocument.getGroupByOffset(cursor);
+
+    if (currentStmt) {
+      const uri = `vscode://halcyontechltd.vscode-db2i/sql?content=${encodeURIComponent(sqlDocument.content)}`;
+
+      env.clipboard.writeText(uri);
+      window.showInformationMessage(`Statement URI copied to clipboard.`);
+    }
+  }
+});


### PR DESCRIPTION
Open a statement via URI and runable by another parameter. Can only load `select` and `with` statements.

## How to test

1. checkout the branch
2. build and launch the branch through debug
3. going to a URI:

* vscode://halcyontechltd.vscode-db2i/sql?content=select%20*%20from%20sample.employee&run=true
* vscode://halcyontechltd.vscode-db2i/sql?content=select%20*%20from%20sample.employee

(GitHub won't turn these into hyperlinks. Slack does)