### PR TITLE
Correctly remove listeners when job is cleaned up

### DIFF
--- a/src/connection/sqlJob.ts
+++ b/src/connection/sqlJob.ts
@@ -210,5 +210,6 @@ export class OldSQLJob extends SQLJob {
     this.channel.close();
     this.channel = undefined;
     this.status = "ended";
+    this.responseEmitter.removeAllListeners();
   }
 }


### PR DESCRIPTION
Fixes a bug where the cancel button would display after altering connection settings, when in fact it should remain as play.