### PR TITLE
Editable cells

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vscode-db2i",
-  "version": "1.6.0",
+  "version": "1.6.3-scott12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vscode-db2i",
-      "version": "1.6.0",
+      "version": "1.6.3-scott12",
       "dependencies": {
         "@ibm/mapepire-js": "^0.3.0",
         "chart.js": "^4.4.2",
@@ -14,7 +14,6 @@
         "json-to-markdown-table": "^1.0.0",
         "lru-cache": "^6.0.0",
         "node-fetch": "^3.3.1",
-        "ollama": "^0.5.2",
         "showdown": "^2.1.0",
         "sql-formatter": "^14.0.0"
       },
@@ -4813,9 +4812,9 @@
       "dev": true
     },
     "node_modules/cross-spawn": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
       "dev": true,
       "dependencies": {
         "path-key": "^3.1.0",
@@ -9057,14 +9056,6 @@
         "node": ">= 18"
       }
     },
-    "node_modules/ollama": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/ollama/-/ollama-0.5.2.tgz",
-      "integrity": "sha512-nH9WEU8lGxX2RhTH9TukjwrQBlyoprIh8wIGMfFlprgzzJgAr+MFFmHzCt7BZt4SMFMXVwM2xnKrfshfHkBLyQ==",
-      "dependencies": {
-        "whatwg-fetch": "^3.6.20"
-      }
-    },
     "node_modules/once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -12771,7 +12762,8 @@
     "node_modules/whatwg-fetch": {
       "version": "3.6.20",
       "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.6.20.tgz",
-      "integrity": "sha512-EqhiFU6daOA8kpjOWTL0olhVOF3i7OrFzSYiGsEMB8GcXS+RrzauAERX65xMeNWVqxA6HXH2m69Z9LaKKdisfg=="
+      "integrity": "sha512-EqhiFU6daOA8kpjOWTL0olhVOF3i7OrFzSYiGsEMB8GcXS+RrzauAERX65xMeNWVqxA6HXH2m69Z9LaKKdisfg==",
+      "dev": true
     },
     "node_modules/whatwg-mimetype": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-db2i",
   "displayName": "Db2 for IBM i",
   "description": "Db2 for IBM i tools in VS Code",
-  "version": "1.6.3-scott3",
+  "version": "1.6.3-scott6",
   "engines": {
     "vscode": "^1.95.0"
   },

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-db2i",
   "displayName": "Db2 for IBM i",
   "description": "Db2 for IBM i tools in VS Code",
-  "version": "1.6.3-scott11",
+  "version": "1.6.3-scott12",
   "engines": {
     "vscode": "^1.95.0"
   },

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-db2i",
   "displayName": "Db2 for IBM i",
   "description": "Db2 for IBM i tools in VS Code",
-  "version": "1.6.3-scott9",
+  "version": "1.6.3-scott10",
   "engines": {
     "vscode": "^1.95.0"
   },

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-db2i",
   "displayName": "Db2 for IBM i",
   "description": "Db2 for IBM i tools in VS Code",
-  "version": "1.6.3-scott10",
+  "version": "1.6.3-scott11",
   "engines": {
     "vscode": "^1.95.0"
   },

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-db2i",
   "displayName": "Db2 for IBM i",
   "description": "Db2 for IBM i tools in VS Code",
-  "version": "1.6.3",
+  "version": "1.6.3-scott2",
   "engines": {
     "vscode": "^1.95.0"
   },

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-db2i",
   "displayName": "Db2 for IBM i",
   "description": "Db2 for IBM i tools in VS Code",
-  "version": "1.6.3-scott8",
+  "version": "1.6.3-scott9",
   "engines": {
     "vscode": "^1.95.0"
   },

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-db2i",
   "displayName": "Db2 for IBM i",
   "description": "Db2 for IBM i tools in VS Code",
-  "version": "1.6.3-scott6",
+  "version": "1.6.3-scott8",
   "engines": {
     "vscode": "^1.95.0"
   },

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-db2i",
   "displayName": "Db2 for IBM i",
   "description": "Db2 for IBM i tools in VS Code",
-  "version": "1.6.3-scott2",
+  "version": "1.6.3-scott3",
   "engines": {
     "vscode": "^1.95.0"
   },

--- a/src/database/table.ts
+++ b/src/database/table.ts
@@ -37,6 +37,14 @@ export default class Table {
     return JobManager.runSQL(sql);
   }
 
+  static async isPartitioned(schema: string, name: string): Promise<boolean> {
+    const sql = `select table_name, partitioned_table from qsys2.sysfiles where table_schema = ? and table_name = ? and partitioned_table is not null and partitioned_table = 'YES'`;
+    const parameters = [schema, name];
+
+    const result = await JobManager.runSQL(sql, {parameters});
+    return result.length > 0;
+  }
+
   static async clearFile(library: string, objectName: string): Promise<void> {
     const command = `CLRPFM ${library}/${objectName}`;
               

--- a/src/database/table.ts
+++ b/src/database/table.ts
@@ -1,8 +1,6 @@
 
-import vscode from "vscode"
 import { JobManager } from "../config";
 import { getInstance } from "../base";
-import Statement from "./statement";
 
 export default class Table {
   /**

--- a/src/database/table.ts
+++ b/src/database/table.ts
@@ -30,11 +30,38 @@ export default class Table {
       `    column.table_schema = key.table_schema and`,
       `    column.table_name = key.table_name and`,
       `    column.column_name = key.column_name`,
-      `WHERE column.TABLE_SCHEMA = '${schema}' AND column.TABLE_NAME = '${name}'`,
+      `WHERE column.TABLE_SCHEMA = ? AND column.TABLE_NAME = ?`,
       `ORDER BY column.ORDINAL_POSITION`,
     ].join(` `);
 
-    return JobManager.runSQL(sql);
+    return JobManager.runSQL(sql, {parameters: [schema, name]});
+  }
+
+  /**
+   * This is to be used instead of getItems when the table is in session/QTEMP
+   */
+  static async getSessionItems(name: string): Promise<TableColumn[]> {
+    const sql = [
+      `SELECT `,
+      `  column.TABLE_SCHEMA,`,
+      `  column.TABLE_NAME,`,
+      `  column.COLUMN_NAME,`,
+      `  '' as CONSTRAINT_NAME,`,
+      `  column.DATA_TYPE, `,
+      `  column.CHARACTER_MAXIMUM_LENGTH,`,
+      `  column.NUMERIC_SCALE, `,
+      `  column.NUMERIC_PRECISION,`,
+      `  column.IS_NULLABLE, `,
+      `  column.HAS_DEFAULT, `,
+      `  column.COLUMN_DEFAULT, `,
+      `  column.COLUMN_TEXT, `,
+      `  column.IS_IDENTITY`,
+      `FROM QSYS2.SYSCOLUMNS2_SESSION as column`,
+      `WHERE column.TABLE_NAME = ?`,
+      `ORDER BY column.ORDINAL_POSITION`,
+    ].join(` `);
+
+    return JobManager.runSQL(sql, {parameters: [name]});
   }
 
   static async isPartitioned(schema: string, name: string): Promise<boolean> {

--- a/src/language/sql/statement.ts
+++ b/src/language/sql/statement.ts
@@ -20,7 +20,7 @@ export default class Statement {
 			first = this.tokens[2];
 		}
 
-		if (tokenIs(first, `word`) && tokenIs(this.tokens[1], `colon`)) {
+		if (first.value !== undefined && tokenIs(this.tokens[1], `colon`)) {
 			// Possible label?
 			this.label = first.value;
 			first = this.tokens[2];

--- a/src/views/html.ts
+++ b/src/views/html.ts
@@ -20,11 +20,14 @@ export function getHeader(options: {withCollapsed?: boolean} = {}): string {
       top: 0;           /* Don't forget this, required for the stickiness */
     }
 
+    tfoot {
+      position: sticky;
+      bottom: 0;
+    }
+
     tfoot tr {
       background-color: var(--vscode-multiDiffEditor-headerBackground);
       text-align: left;
-      position: sticky; /* Lock the footer row to the bottom so it's always visible as rows are scrolled */
-      bottom: 0;        /* Don't forget this, required for the stickiness */
     }
 
     #resultset th,

--- a/src/views/html.ts
+++ b/src/views/html.ts
@@ -9,7 +9,7 @@ export function getHeader(options: {withCollapsed?: boolean} = {}): string {
       border-collapse: collapse;
       font-size: 0.9em;
       font-family: sans-serif;
-      min-width: 400px;
+      min-width: 100%;
     }
 
     thead tr {

--- a/src/views/results/html.ts
+++ b/src/views/results/html.ts
@@ -44,6 +44,7 @@ export interface BasicColumn {
   name: string;
   useInWhere: boolean
   jsType: "number"|"asString";
+  maxInputLength?: number;
 }
 
 export function generateScroller(basicSelect: string, isCL: boolean, withCancel?: boolean, updatable?: UpdatableInfo): string {
@@ -156,9 +157,13 @@ export function generateScroller(basicSelect: string, isCL: boolean, withCancel?
                   editableNode.removeEventListener('keydown', keydownEvent);
 
                   editableNode.contentEditable = false;
-                  const newValue = editableNode.innerText;
+                  let newValue = editableNode.innerText;
 
                   if (newValue === chosenValue) return;
+                  if (chosenColumnDetail.maxInputLength && newValue.length > chosenColumnDetail.maxInputLength) {
+                    newValue = newValue.substring(0, chosenColumnDetail.maxInputLength);
+                    editableNode.innerText = newValue;
+                  }
 
                   const useRrn = updateKeyColumns.length === 1 && updateKeyColumns.some(col => col.name === 'RRN');
 

--- a/src/views/results/html.ts
+++ b/src/views/results/html.ts
@@ -248,7 +248,7 @@ export function generateScroller(basicSelect: string, isCL: boolean, withCancel?
                   if (data.rows === undefined && totalRows === 0) {
                     document.getElementById(messageSpanId).innerText = 'Statement executed with no result set returned. Rows affected: ' + data.update_count;
                   } else {
-                    document.getElementById(statusId).innerText = noMoreRows ? ('Loaded ' + totalRows + '. End of data.') : ('Loaded ' + totalRows + '. More available.');
+                    document.getElementById(statusId).innerText = (noMoreRows ? ('Loaded ' + totalRows + '. End of data.') : ('Loaded ' + totalRows + '. More available.')) + ' ' + (updateTable ? 'Updatable.' : '');
                     document.getElementById(jobId).innerText = data.jobId ? data.jobId : '';
                     document.getElementById(messageSpanId).style.visibility = "hidden";
                   }

--- a/src/views/results/html.ts
+++ b/src/views/results/html.ts
@@ -511,7 +511,7 @@ export function generateScroller(basicSelect: string, isCL: boolean, withCancel?
           <tbody></tbody>
           <tfoot id="resultfooter"></tfoot>
           </table>
-        <p id="messageSpan"></p>
+        <p style="padding-left: 20px;" id="messageSpan"></p>
         <div id="spinnerContent" class="center-screen">
           <p id="loadingText">Running statement</p>
           <span class="loader"></span>

--- a/src/views/results/html.ts
+++ b/src/views/results/html.ts
@@ -140,7 +140,7 @@ export function generateScroller(basicSelect: string, isCL: boolean, withCancel?
                 editableNode.focus();
 
                 const keydownEvent = (e) => {
-                  if (e.keyCode === 13) {
+                  if (e.key === 'Enter') {  
                     e.preventDefault();
                     finishEditing();
                   }

--- a/src/views/results/html.ts
+++ b/src/views/results/html.ts
@@ -131,9 +131,15 @@ document.getElementById('resultset').onclick = function(e){
         }
       }
 
-      if (e.key === 'Enter') {
-        e.preventDefault();
-        finishEditing();
+      switch (e.key) {
+        case 'Enter':
+          e.preventDefault();
+          finishEditing();
+          break;
+        case 'Escape':
+          editableNode.innerHTML = chosenValue;
+          finishEditing();
+          break;
       }
     }
 

--- a/src/views/results/html.ts
+++ b/src/views/results/html.ts
@@ -74,6 +74,8 @@ function handleCellResponse(id, success) {
   }
 }
 
+const validKeyPresses = ['Enter', 'Backspace', 'Delete', 'ArrowLeft', 'ArrowRight'];
+
 document.getElementById('resultset').onclick = function(e){
   console.log('click')
   if (updateTable === undefined) return;
@@ -123,9 +125,15 @@ document.getElementById('resultset').onclick = function(e){
     editableNode.focus();
 
     const keydownEvent = (e) => {
-      if (e.key === 'Enter') {  
+      if (chosenColumnDetail.maxInputLength && editableNode.innerText.length >= chosenColumnDetail.maxInputLength) {
+        if (!validKeyPresses.includes(e.key)) {
+          e.preventDefault();
+        }
+      }
+
+      if (e.key === 'Enter') {
         e.preventDefault();
-        finishEditing(e.target);
+        finishEditing();
       }
     }
 
@@ -205,7 +213,7 @@ document.getElementById('resultset').onclick = function(e){
       e.stopPropagation();
       console.log('blur');
       // Code to execute when the element loses focus
-      finishEditing(e.target);
+      finishEditing();
     }, {once: true});
 
     editableNode.addEventListener('keydown', keydownEvent);

--- a/src/views/results/html.ts
+++ b/src/views/results/html.ts
@@ -129,19 +129,19 @@ document.getElementById('resultset').onclick = function(e){
       }
     }
 
-    const finishEditing = (currentNode) => {
-      if (currentNode === undefined) return;
+    const finishEditing = () => {
+      if (editableNode === undefined) return;
 
       // Remove keydown listener
-      currentNode.removeEventListener('keydown', keydownEvent);
+      editableNode.removeEventListener('keydown', keydownEvent);
 
-      currentNode.contentEditable = false;
-      let newValue = currentNode.innerText;
+      editableNode.contentEditable = false;
+      let newValue = editableNode.innerText;
 
       if (newValue === chosenValue) return;
       if (chosenColumnDetail.maxInputLength && newValue.length > chosenColumnDetail.maxInputLength) {
         newValue = newValue.substring(0, chosenColumnDetail.maxInputLength);
-        currentNode.innerText = newValue;
+        editableNode.innerText = newValue;
       }
 
       const useRrn = updateKeyColumns.length === 1 && updateKeyColumns.some(col => col.name === 'RRN');
@@ -159,7 +159,7 @@ document.getElementById('resultset').onclick = function(e){
               bindings.push(newValue);
               updateStatement += '?';
             } else {
-              currentNode.innerHTML = chosenValue;
+              editableNode.innerHTML = chosenValue;
               return;
             }
             break;
@@ -196,9 +196,9 @@ document.getElementById('resultset').onclick = function(e){
         }
       }
 
-      currentNode = undefined;
+      requestCellUpdate(editableNode, chosenValue, updateStatement, bindings);
 
-      requestCellUpdate(currentNode, chosenValue, updateStatement, bindings);
+      editableNode = undefined;
     }
 
     editableNode.addEventListener('blur', (e) => {

--- a/src/views/results/html.ts
+++ b/src/views/results/html.ts
@@ -103,7 +103,14 @@ document.getElementById('resultset').onclick = function(e){
     trWithColumn = target.parentElement;
   }
   else if (target.tagName.toLowerCase() == "td") {
-    // get the inner div
+    // Usually means it is blank
+    if (!target.firstChild) {
+      // Add a div to the cell
+      const newDiv = document.createElement("div");
+      newDiv.innerText = '';
+      target.appendChild(newDiv);
+    }
+    
     originalValue = target.firstChild.innerText;
     editableNode = target;
     trWithColumn = target;

--- a/src/views/results/html.ts
+++ b/src/views/results/html.ts
@@ -498,7 +498,7 @@ export function generateScroller(basicSelect: string, isCL: boolean, withCancel?
           }
         </script>
       </head>
-      <body>
+      <body style="padding: 0;">
         <table id="resultset">
           <thead></thead>
           <tbody></tbody>

--- a/src/views/results/html.ts
+++ b/src/views/results/html.ts
@@ -119,6 +119,8 @@ export function generateScroller(basicSelect: string, isCL: boolean, withCancel?
 
               if (trWithColumn && trWithColumn.column) {
                 const chosenColumn = trWithColumn.column;
+                if (chosenColumn === 'RRN') return;
+
                 const chosenColumnDetail = updateTable.columns.find(col => col.name === chosenColumn);
                 if (!chosenColumnDetail) return;
                 
@@ -158,8 +160,10 @@ export function generateScroller(basicSelect: string, isCL: boolean, withCancel?
 
                   if (newValue === chosenValue) return;
 
+                  const useRrn = updateKeyColumns.length === 1 && updateKeyColumns.some(col => col.name === 'RRN');
+
                   let bindings = [];
-                  let updateStatement = 'UPDATE ' + updateTable.table + ' SET ' + chosenColumn + ' = ';
+                  let updateStatement = 'UPDATE ' + updateTable.table + ' t SET t.' + chosenColumn + ' = ';
 
                   if (newValue === 'null') {
                     updateStatement += 'NULL';
@@ -187,7 +191,13 @@ export function generateScroller(basicSelect: string, isCL: boolean, withCancel?
                   
                   for (let i = 0; i < updateKeyColumns.length; i++) {
                     if (idValues[i] === 'null') continue;
-                    updateStatement += updateKeyColumns[i].name + ' = ?';
+
+                    if (useRrn && updateKeyColumns[i].name === 'RRN') {
+                      updateStatement += 'RRN(t) = ?';
+                    } else {
+                      updateStatement += updateKeyColumns[i].name + ' = ?';
+                    }
+
                     switch (updateKeyColumns[i].jsType) {
                       case 'number':
                         bindings.push(Number(idValues[i]));

--- a/src/views/results/html.ts
+++ b/src/views/results/html.ts
@@ -125,6 +125,7 @@ export function generateScroller(basicSelect: string, isCL: boolean, withCancel?
                 const parentRow = trWithColumn.parentElement;
 
                 const updateKeyColumns = updateTable.columns.filter(col => col.useInWhere);
+                if (updateKeyColumns.length === 0) return;
 
                 let idValues = [];
                 for (let i = 0; i < parentRow.cells.length; i++) {

--- a/src/views/results/html.ts
+++ b/src/views/results/html.ts
@@ -120,6 +120,8 @@ export function generateScroller(basicSelect: string, isCL: boolean, withCancel?
               if (trWithColumn && trWithColumn.column) {
                 const chosenColumn = trWithColumn.column;
                 const chosenColumnDetail = updateTable.columns.find(col => col.name === chosenColumn);
+                if (!chosenColumnDetail) return;
+                
                 const parentRow = trWithColumn.parentElement;
 
                 const updateKeyColumns = updateTable.columns.filter(col => col.useInWhere);

--- a/src/views/results/index.ts
+++ b/src/views/results/index.ts
@@ -6,7 +6,7 @@ import * as csv from "csv/sync";
 
 import { JobManager } from "../../config";
 import Document from "../../language/sql/document";
-import { ParsedEmbeddedStatement, StatementGroup, StatementType } from "../../language/sql/types";
+import { ObjectRef, ParsedEmbeddedStatement, StatementGroup, StatementType } from "../../language/sql/types";
 import Statement from "../../language/sql/statement";
 import { ExplainTree } from "./explain/nodes";
 import { DoveResultsView, ExplainTreeItem } from "./explain/doveResultsView";
@@ -224,7 +224,13 @@ async function runHandler(options?: StatementInfo) {
           if (inWindow) {
             useWindow(possibleTitle, options.viewColumn);
           }
-          chosenView.setScrolling(statementDetail.content, false, undefined, inWindow); // Never errors
+
+          let updatableTable: ObjectRef | undefined;
+          if (statement.type === StatementType.Select && refs.length === 1) {
+            updatableTable = refs[0];
+          }
+
+          chosenView.setScrolling(statementDetail.content, false, undefined, inWindow, updatableTable); // Never errors
 
         } else if ([`explain`, `onlyexplain`].includes(statementDetail.qualifier)) {
           // If it's an explain, we need to 

--- a/src/views/results/index.ts
+++ b/src/views/results/index.ts
@@ -18,7 +18,7 @@ import { updateStatusBar } from "../jobManager/statusBar";
 import { ExplainType } from "@ibm/mapepire-js/dist/src/types";
 import { DbCache } from "../../language/providers/logic/cache";
 
-export type StatementQualifier = "statement" | "explain" | "onlyexplain" | "json" | "csv" | "cl" | "sql";
+export type StatementQualifier = "statement" | "update" | "explain" | "onlyexplain" | "json" | "csv" | "cl" | "sql";
 
 export interface StatementInfo {
   content: string,
@@ -219,14 +219,14 @@ async function runHandler(options?: StatementInfo) {
           }
           chosenView.setScrolling(statementDetail.content, true); // Never errors
           
-        } else if (statementDetail.qualifier === `statement`) {
+        } else if ([`statement`, `update`].includes(statementDetail.qualifier)) {
           // If it's a basic statement, we can let it scroll!
           if (inWindow) {
             useWindow(possibleTitle, options.viewColumn);
           }
 
           let updatableTable: ObjectRef | undefined;
-          if (statement.type === StatementType.Select && refs.length === 1) {
+          if (statementDetail.qualifier === `update` && statement.type === StatementType.Select && refs.length === 1) {
             updatableTable = refs[0];
           }
 
@@ -394,7 +394,7 @@ export function parseStatement(editor?: vscode.TextEditor, existingInfo?: Statem
     }
 
     if (statementInfo.content) {
-      [`cl`, `json`, `csv`, `sql`, `explain`].forEach(mode => {
+      [`cl`, `json`, `csv`, `sql`, `explain`, `update`].forEach(mode => {
         if (statementInfo.content.trim().toLowerCase().startsWith(mode + `:`)) {
           statementInfo.content = statementInfo.content.substring(mode.length + 1).trim();
 

--- a/src/views/results/resultSetPanelProvider.ts
+++ b/src/views/results/resultSetPanelProvider.ts
@@ -194,10 +194,16 @@ export class ResultSetPanelProvider implements WebviewViewProvider {
 
         const isPartitioned = await Table.isPartitioned(goodSchema, goodName);
         if (!isPartitioned) {
-          const tableInfo = await Table.getItems(
-            goodSchema,
-            goodName
-          );
+          let tableInfo: TableColumn[] = [];
+
+          if ([`SESSION`, `QTEMP`].includes(goodSchema)) {
+            tableInfo = await Table.getSessionItems(goodName);
+          } else {
+            tableInfo = await Table.getItems(
+              goodSchema,
+              goodName
+            );
+          }
 
           const uneditableTypes = [`VARBIN`, `BINARY`, `ROWID`, `DATALINK`, `DBCLOB`, `BLOB`, `GRAPHIC`]
 

--- a/src/views/results/resultSetPanelProvider.ts
+++ b/src/views/results/resultSetPanelProvider.ts
@@ -51,9 +51,10 @@ export class ResultSetPanelProvider implements WebviewViewProvider {
           break;
 
         case `update`:
-          if (message.update) {
+          console.log(`update`, message);
+          if (message.update && message.bindings) {
             try {
-              const result = await JobManager.runSQL(message.update);
+              const result = await JobManager.runSQL(message.update, {parameters: message.bindings});
             } catch (e) {
               this.setError(e.message);
               if (this.currentQuery) {
@@ -184,7 +185,7 @@ export class ResultSetPanelProvider implements WebviewViewProvider {
         if (tableInfo.length > 0) {
           var currentColumns: html.BasicColumn[]|undefined;
       
-          currentColumns = tableInfo.map((column) => ({name: column.COLUMN_NAME, jsType: column.NUMERIC_PRECISION ? `number` : `string`, useInWhere: column.IS_IDENTITY === `YES` || column.CONSTRAINT_NAME !== null}));
+          currentColumns = tableInfo.map((column) => ({name: column.COLUMN_NAME, jsType: column.NUMERIC_PRECISION ? `number` : `asString`, useInWhere: column.IS_IDENTITY === `YES` || column.CONSTRAINT_NAME !== null}));
 
           if (currentColumns.some(c => c.useInWhere)) {
             updatable = {

--- a/src/views/results/resultSetPanelProvider.ts
+++ b/src/views/results/resultSetPanelProvider.ts
@@ -61,6 +61,7 @@ export class ResultSetPanelProvider implements WebviewViewProvider {
 
         case `update`:
           if (message.id && message.update && message.bindings) {
+            console.log(message);
             try {
               const result = await JobManager.runSQL(message.update, {parameters: message.bindings});
               postCellResponse(message.id, true);
@@ -199,7 +200,7 @@ export class ResultSetPanelProvider implements WebviewViewProvider {
           currentColumns = tableInfo.map((column) => ({
             name: column.COLUMN_NAME, 
             jsType: column.NUMERIC_PRECISION ? `number` : `asString`, 
-            useInWhere: column.IS_IDENTITY === `YES` || column.CONSTRAINT_NAME !== null,
+            useInWhere: column.IS_IDENTITY === `YES`,
             maxInputLength: column.CHARACTER_MAXIMUM_LENGTH
           }));
 

--- a/src/views/results/resultSetPanelProvider.ts
+++ b/src/views/results/resultSetPanelProvider.ts
@@ -184,7 +184,12 @@ export class ResultSetPanelProvider implements WebviewViewProvider {
         if (tableInfo.length > 0) {
           let currentColumns: html.BasicColumn[]|undefined;
       
-          currentColumns = tableInfo.map((column) => ({name: column.COLUMN_NAME, jsType: column.NUMERIC_PRECISION ? `number` : `asString`, useInWhere: column.IS_IDENTITY === `YES` || column.CONSTRAINT_NAME !== null}));
+          currentColumns = tableInfo.map((column) => ({
+            name: column.COLUMN_NAME, 
+            jsType: column.NUMERIC_PRECISION ? `number` : `asString`, 
+            useInWhere: column.IS_IDENTITY === `YES` || column.CONSTRAINT_NAME !== null,
+            maxInputLength: column.CHARACTER_MAXIMUM_LENGTH
+          }));
 
           if (!currentColumns.some(c => c.useInWhere)) {
             // We need to override the input statement if they want to do updatable

--- a/src/views/results/resultSetPanelProvider.ts
+++ b/src/views/results/resultSetPanelProvider.ts
@@ -186,12 +186,15 @@ export class ResultSetPanelProvider implements WebviewViewProvider {
       
           currentColumns = tableInfo.map((column) => ({name: column.COLUMN_NAME, jsType: column.NUMERIC_PRECISION ? `number` : `asString`, useInWhere: column.IS_IDENTITY === `YES` || column.CONSTRAINT_NAME !== null}));
 
-          if (currentColumns.some(c => c.useInWhere)) {
-            updatable = {
-              table: schema + `.` + ref.object.name,
-              columns: currentColumns
-            }
+          if (!currentColumns.some(c => c.useInWhere)) {
+            // Let's fallback and use all the columns in the where!
+            currentColumns = tableInfo.map((column) => ({name: column.COLUMN_NAME, jsType: column.NUMERIC_PRECISION ? `number` : `asString`, useInWhere: true}))
           }
+
+          updatable = {
+            table: schema + `.` + ref.object.name,
+            columns: currentColumns
+          };
         }
       }
     }

--- a/src/views/results/resultSetPanelProvider.ts
+++ b/src/views/results/resultSetPanelProvider.ts
@@ -51,7 +51,6 @@ export class ResultSetPanelProvider implements WebviewViewProvider {
           break;
 
         case `update`:
-          console.log(`update`, message);
           if (message.update && message.bindings) {
             try {
               const result = await JobManager.runSQL(message.update, {parameters: message.bindings});


### PR DESCRIPTION
Introducing the `update` prefix. When used in combination with a `select` statement that only references one table, then the cells will become updatable. A fully qualified table must be used.

* Try using `update: select * from schema.table`
* Click on a cell for it to become editable
* Either click off the cell or use Enter to submit
* The update is ran as soon as the cell loses focus

Tested column types:

- Numbers
- Strings/Chars
- Date/Times/Timestamp
- Can set as null