### PR TITLE
Reduce default chart size to 80% of available screen

### DIFF
--- a/src/notebooks/logic/chartJs.ts
+++ b/src/notebooks/logic/chartJs.ts
@@ -31,7 +31,7 @@ export function generateChartHTMLEmbedded(id: number, detail: ChartDetail, label
 
   const hasYaxis = detail.type === `bar` || detail.type === `line`;
 
-  const script = /*javascript*/`
+  const script = /*javascript*/ `
   if (!window.ibmicharts) {
     window.ibmicharts = {};
   }
@@ -44,8 +44,8 @@ export function generateChartHTMLEmbedded(id: number, detail: ChartDetail, label
         const maxHeight = window.innerHeight * 0.8;
         const maxWidth = window.innerWidth * 0.8;
         const targetSize = Math.min(maxHeight, maxWidth);
-        chartEle.style.maxHeight = `${targetSize}px`;
-        chartEle.style.maxWidth = `${targetSize}px`;  
+        chartEle.style.maxHeight = targetSize + 'px';
+        chartEle.style.maxWidth = targetSize + 'px';  
         try {
           window.ibmicharts['myChart${id}'] = new Chart(chartEle.getContext('2d'), {
             type: '${detail.type}',

--- a/src/notebooks/logic/chartJs.ts
+++ b/src/notebooks/logic/chartJs.ts
@@ -41,6 +41,11 @@ export function generateChartHTMLEmbedded(id: number, detail: ChartDetail, label
     if (!theChart) {
       const chartEle = document.getElementById('myChart${id}');
       if (chartEle) {
+        const maxHeight = window.innerHeight * 0.8;
+        const maxWidth = window.innerWidth * 0.8;
+        const targetSize = Math.min(maxHeight, maxWidth);
+        chartEle.style.maxHeight = `${targetSize}px`;
+        chartEle.style.maxWidth = `${targetSize}px`;  
         try {
           window.ibmicharts['myChart${id}'] = new Chart(chartEle.getContext('2d'), {
             type: '${detail.type}',


### PR DESCRIPTION
Reduce chart size to be 80% of the available height or width, whichever is smaller.

At the moment, the charts are generated to the maximum available width, which is a poor experience on desktops. This will limit the size to be the maximum of 80% of the height / width (whichever is smaller).

For example:
![image](https://github.com/user-attachments/assets/94fb37ce-b4ce-4edf-b389-3bf7c5a8ebaf)
