### PR TITLE
Prevent sql tokenizer from assuming FOR is a statementType when used with data-type

### DIFF
--- a/src/language/sql/tests/statements.test.ts
+++ b/src/language/sql/tests/statements.test.ts
@@ -149,6 +149,17 @@ parserScenarios(`Object references`, ({newDoc}) => {
     expect(obj.alias).toBe(`a`)
   });
 
+  test('SELECT: for in data-type (issue #315)', () => {
+    const document = newDoc([
+      `select cast(x'01' as char(1) for bit data) as something,`,
+      `case when 1=1 then 'makes sense' else 'what?' end as something_else`,
+      `from sysibm.sysdummy1;`
+    ].join(`\n`));
+  
+    expect(document.statements.length).toBe(1);
+    expect(document.statements[0].type).toBe(StatementType.Select);
+  });
+
   test('SELECT: Simple qualified object with alias (no AS)', () => {
     const document = newDoc(`select * from myschema.sample a;`);
 

--- a/src/language/sql/tests/tokens.test.ts
+++ b/src/language/sql/tests/tokens.test.ts
@@ -108,3 +108,17 @@ test(`Block comments`, () => {
   expect(tokens[0].value).toBe(`Create`)
   expect(lines.substring(tokens[0].range.start, tokens[0].range.end)).toBe(`Create`)
 });
+
+test('For in data-type (issue #315)', () => {
+  const tokeniser = new SQLTokeniser();
+
+  const tokens = tokeniser.tokenise([
+    `select cast(x'01' as char(1) for bit data) as something,`,
+    `case when 1=1 then 'makes sense' else 'what?' end as something_else`,
+    `from sysibm.sysdummy1;`
+  ].join(`\n`));
+
+  expect(tokens.length).toBe(35);
+  expect(tokens[9].type).toBe(`word`);
+  expect(tokens[9].value.toLowerCase()).toBe(`for`);
+});

--- a/src/language/sql/tokens.ts
+++ b/src/language/sql/tokens.ts
@@ -303,6 +303,10 @@ export default class SQLTokeniser {
           }
         }
 
+        if (i > 0 && i < tokens.length - 2 && tokens[i].value.toLowerCase() === 'for' && tokens[i - 1].type === 'closebracket' && tokens[i + 2].value.toLowerCase() === 'data') {
+          goodMatch = false; // data-type with FOR BIT/SBCS/MIXED DATA
+        }
+
         if (goodMatch) {
           const matchedTokens = tokens.slice(i, i + type.match.length);
           const value = state.content.substring(matchedTokens[0].range.start, matchedTokens[matchedTokens.length - 1].range.end);


### PR DESCRIPTION
Fixes #315 

Modified fixStatement to not assign statementType for "**FOR**" when:
* Previous token is "closebracket"
* Token after the next is the word "**DATA**"