### PR TITLE
Remove duplicates from library list

### DIFF
--- a/src/connection/manager.ts
+++ b/src/connection/manager.ts
@@ -30,7 +30,7 @@ export class SQLJobManager {
       const config = instance.getConfig();
 
       const newJob = predefinedJob || (new OldSQLJob({
-        libraries: [config.currentLibrary, ...config.libraryList],
+        libraries: uniqueStrings([config.currentLibrary, ...config.libraryList]),
         naming: `system`,
         "full open": false,
         "transaction isolation": "none",
@@ -162,3 +162,9 @@ export class SQLJobManager {
     return Configuration.get<SelfValue>(`jobSelfDefault`) || `*NONE`;
   }
 }
+
+const uniqueStrings = (arr: string[]): string[] => {
+  return arr.filter((item,
+      index) => arr.indexOf(item) === index);
+}
+

--- a/src/connection/manager.ts
+++ b/src/connection/manager.ts
@@ -30,7 +30,7 @@ export class SQLJobManager {
       const config = instance.getConfig();
 
       const newJob = predefinedJob || (new OldSQLJob({
-        libraries: uniqueStrings([config.currentLibrary, ...config.libraryList]),
+        libraries: [config.currentLibrary, ...config.libraryList].filter((item, index, arr) => arr.indexOf(item) === index),
         naming: `system`,
         "full open": false,
         "transaction isolation": "none",
@@ -162,9 +162,3 @@ export class SQLJobManager {
     return Configuration.get<SelfValue>(`jobSelfDefault`) || `*NONE`;
   }
 }
-
-const uniqueStrings = (arr: string[]): string[] => {
-  return arr.filter((item,
-      index) => arr.indexOf(item) === index);
-}
-

--- a/src/connection/manager.ts
+++ b/src/connection/manager.ts
@@ -30,7 +30,7 @@ export class SQLJobManager {
       const config = instance.getConfig();
 
       const newJob = predefinedJob || (new OldSQLJob({
-        libraries: [config.currentLibrary, ...config.libraryList].filter((item, index, arr) => arr.indexOf(item) === index),
+        libraries: [config.currentLibrary, ...config.libraryList.filter((item) => item != config.currentLibrary)],
         naming: `system`,
         "full open": false,
         "transaction isolation": "none",


### PR DESCRIPTION
Fixes #306 

SQLJobManager modified to remove duplicates from library list. This might happen if current library is also in the user library list. The server job shows this in its joblog:

<img width="412" alt="image" src="https://github.com/user-attachments/assets/e355e5a4-2584-4404-a88c-ff8fff42f154" />
