### PR TITLE
fix: check if SELF data is undefined

### DIFF
--- a/src/aiProviders/continue/continueContextProvider.ts
+++ b/src/aiProviders/continue/continueContextProvider.ts
@@ -87,7 +87,7 @@ export class db2ContextProvider implements IContextProvider {
       const result = await selected.job
         .query<SelfCodeNode>(content)
         .execute(10000);
-      if (result.success) {
+      if (result.success && result.data) {
         const data: SelfCodeNode[] = result.data.map((row) => ({
           ...row,
           INITIAL_STACK: this.tryParseJson(row),

--- a/src/views/jobManager/selfCodes/selfCodesResultsView.ts
+++ b/src/views/jobManager/selfCodes/selfCodesResultsView.ts
@@ -145,7 +145,7 @@ export class selfCodesResultsView implements TreeDataProvider<any> {
 
     try {
       const result = await selected.job.query<SelfCodeNode>(content).execute(10000);
-      if (result.success) {
+      if (result.success && result.data) {
         const data: SelfCodeNode[] = result.data.map((row) => ({
           ...row,
           INITIAL_STACK: JSON.parse(row.INITIAL_STACK as unknown as string)


### PR DESCRIPTION
closes #320 

This pull request includes a small change to the `src/views/jobManager/selfCodes/selfCodesResultsView.ts` file. The change adds a check to ensure that `result.data` is not null before proceeding with the data mapping.

* [`src/views/jobManager/selfCodes/selfCodesResultsView.ts`](diffhunk://#diff-60fcb8be549b022924d679b35b31d2d9cca3998e8ea24632b64e8a8b8d30ad54L148-R148): Added a condition to check if `result.data` is present before processing it.