### PR TITLE
Fix linebreaks in generated SQL

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vscode-db2i",
-  "version": "1.7.0-syntaxcheck11",
+  "version": "1.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vscode-db2i",
-      "version": "1.7.0-syntaxcheck11",
+      "version": "1.8.0",
       "dependencies": {
         "@ibm/mapepire-js": "^0.3.0",
         "chart.js": "^4.4.2",
@@ -19,7 +19,7 @@
       },
       "devDependencies": {
         "@continuedev/core": "^1.0.13",
-        "@halcyontech/vscode-ibmi-types": "^2.14.0",
+        "@halcyontech/vscode-ibmi-types": "^2.14.5",
         "@types/glob": "^7.1.3",
         "@types/node": "18.x",
         "@types/vscode": "^1.95.0",
@@ -12550,9 +12550,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.21.0.tgz",
-      "integrity": "sha512-BUgJXc752Kou3oOIuU1i+yZZypyZRqNPW0vqoMPl8VaoalSfeR0D8/t4iAS3yirs79SSMTxTag+ZC86uswv+Cw==",
+      "version": "6.21.1",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.21.1.tgz",
+      "integrity": "sha512-q/1rj5D0/zayJB2FraXdaWxbhWiNKDvu8naDT2dl1yTlvJp4BLtOcp2a5BvgGNQpYYJzau7tf1WgKv3b+7mqpQ==",
       "dev": true,
       "engines": {
         "node": ">=18.17"
@@ -12782,9 +12782,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "5.4.11",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.11.tgz",
-      "integrity": "sha512-c7jFQRklXua0mTzneGW9QVyxFjUgwcihC4bXEtujIo2ouWCe1Ajt/amn2PCxYnhYfd5k09JX3SB7OYWFKYqj8Q==",
+      "version": "5.4.14",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.14.tgz",
+      "integrity": "sha512-EK5cY7Q1D8JNhSaPKVK4pwBFvaTmZxEnoKXLG/U9gmdDcihQGNzFlgIvaxezFR4glP1LsuiedwMBqCXH3wZccA==",
       "dev": true,
       "dependencies": {
         "esbuild": "^0.21.3",

--- a/package.json
+++ b/package.json
@@ -970,7 +970,7 @@
         },
         {
           "command": "vscode-db2i.getObjectLocks",
-          "when": "viewItem == table || viewItem == view || viewItem == alias || viewItem == constraint || viewItem == function || viewItem == variable || viewItem == index || viewItem == procedure || viewItem == sequence || viewItem == package || viewItem == trigger || viewItem == type",
+          "when": "viewItem == table || viewItem == view || viewItem == alias || viewItem == function || viewItem == variable || viewItem == index || viewItem == procedure || viewItem == sequence || viewItem == package || viewItem == trigger || viewItem == type",
           "group": "db2workWith@5"
         },
         {
@@ -1322,7 +1322,7 @@
   },
   "devDependencies": {
     "@continuedev/core": "^1.0.13",
-    "@halcyontech/vscode-ibmi-types": "^2.14.0",
+    "@halcyontech/vscode-ibmi-types": "^2.14.5",
     "@types/glob": "^7.1.3",
     "@types/node": "18.x",
     "@types/vscode": "^1.95.0",

--- a/src/database/schemas.ts
+++ b/src/database/schemas.ts
@@ -1,6 +1,6 @@
 
+import path from "path";
 import { getInstance } from "../base";
-
 import { JobManager } from "../config";
 
 export type SQLType = "schemas" | "tables" | "views" | "aliases" | "constraints" | "functions" | "variables" | "indexes" | "procedures" | "sequences" | "packages" | "triggers" | "types" | "logicals";
@@ -220,23 +220,27 @@ export default class Schemas {
    * @param object Not user input
    */
   static async generateSQL(schema: string, object: string, internalType: string): Promise<string> {
-    await JobManager.runSQL<{ SRCDTA: string }>([
-      `CALL QSYS2.GENERATE_SQL( DATABASE_OBJECT_NAME => ?, DATABASE_OBJECT_LIBRARY_NAME => ?, DATABASE_OBJECT_TYPE => ?
-                              , CREATE_OR_REPLACE_OPTION => '1', PRIVILEGES_OPTION => '0'
-                              , DATABASE_SOURCE_FILE_NAME => '*STMF'
-                              , STATEMENT_FORMATTING_OPTION => '0'
-                              , SOURCE_STREAM_FILE => '/tmp/Q_GENSQL_' concat current_user concat '.sql'
-                              , SOURCE_STREAM_FILE_END_OF_LINE => 'LF'
-                              , SOURCE_STREAM_FILE_CCSID => 1208 )`
-    ].join(` `), { parameters: [object, schema, internalType] });
-    const lines = await JobManager.runSQL<{ LINE: string }>(
-      `select LINE
-         from table( QSYS2.IFS_READ( PATH_NAME => '/tmp/Q_GENSQL_' concat current_user concat '.sql' ) )`
-    );
+    const instance = getInstance();
+    const connection = instance.getConnection();
 
-    const generatedStatement = lines.map( elem => elem.LINE ).join(`\n`);
+    const result = await connection.withTempDirectory<string>(async (tempDir) => {
+      const tempFilePath = path.posix.join(tempDir, `generatedSql.sql`);
+      await JobManager.runSQL<{ SRCDTA: string }>([
+        `CALL QSYS2.GENERATE_SQL( DATABASE_OBJECT_NAME => ?, DATABASE_OBJECT_LIBRARY_NAME => ?, DATABASE_OBJECT_TYPE => ?
+                                , CREATE_OR_REPLACE_OPTION => '1', PRIVILEGES_OPTION => '0'
+                                , DATABASE_SOURCE_FILE_NAME => '*STMF'
+                                , STATEMENT_FORMATTING_OPTION => '0'
+                                , SOURCE_STREAM_FILE => '${tempFilePath}'
+                                , SOURCE_STREAM_FILE_END_OF_LINE => 'LF'
+                                , SOURCE_STREAM_FILE_CCSID => 1208 )`
+      ].join(` `), { parameters: [object, schema, internalType] });
 
-    return generatedStatement;
+      // TODO: eventually .content -> .getContent(), it's not available yet
+      const contents = (await connection.content.downloadStreamfileRaw(tempFilePath)).toString();
+      return contents;
+    })
+
+    return result;
   }
 
   static async deleteObject(schema: string, name: string, type: string): Promise<void> {


### PR DESCRIPTION
The Generate SQL output use the result set from the `QSYS2.GENERATE_SQL` procedure, but this is using a source member (in QTEMP) as intermediate storage and thus have a fixed length source line - 80 characters by default.

This is a problem, since identifiers can be split by a linebreak.

An example is the generated source for view `QSYS2.OBJECT_LOCK_INFO` where the lines containing the SELECT is broken in the middle of identifiers and functions:

![billede](https://github.com/user-attachments/assets/d095e1c7-2a83-4caa-902c-90a36dc96fab)

This can not be fixed by the SQL formatter, which will replace a linebreak in an identifier by a space:

![billede](https://github.com/user-attachments/assets/cc33895b-f7e4-4c89-b35f-6c3d33730e7e)

This PR will change the use of the `QSYS2.GENERATE_SQL` procedure to generate a streamfile instead of a source member and read this file. This will eliminate the problem with linebreaks in identifiers:

![billede](https://github.com/user-attachments/assets/268d4df7-dba0-4764-b666-afae51418a78)

After SQL formatting the source will look as expected:

![billede](https://github.com/user-attachments/assets/6abb1704-2999-482a-8d31-42b2174bb927)
