### PR TITLE
Refactor getChildren to use new signature API

### DIFF
--- a/src/views/types/procedure.ts
+++ b/src/views/types/procedure.ts
@@ -3,7 +3,11 @@ import Procedure from "../../database/callable";
 import ParmTreeItem from "./ParmTreeItem";
 
 export async function getChildren(schema: string, specificName: string): Promise<ParmTreeItem[]> {
-  const parms = await Procedure.getParms(schema, specificName);
+  const signatures = await Procedure.getSignaturesFor(schema, [specificName]);
+  const allParms = signatures.map(signature => signature.parms).flat();
+  const removedDupes = allParms.filter((parm, index) => {
+    return allParms.findIndex(p => p.PARAMETER_NAME === parm.PARAMETER_NAME && p.DATA_TYPE === p.DATA_TYPE) === index;
+  });
 
-  return parms.map(parm => new ParmTreeItem(schema, specificName, parm));
+  return removedDupes.map(parm => new ParmTreeItem(schema, specificName, parm));
 }


### PR DESCRIPTION
Fixes bug where parameters were not showing in the schema browser.

Also eliminates duplicate parameters from the procedure signatures in the getChildren function for improved efficiency and clarity.