### PR TITLE
Add null check for selfCodes in getChildren method

### DIFF
--- a/src/views/jobManager/selfCodes/selfCodesResultsView.ts
+++ b/src/views/jobManager/selfCodes/selfCodesResultsView.ts
@@ -231,7 +231,10 @@ class SelfCodeItems extends ExtendedTreeItem {
 
   async getChildren(): Promise<ExtendedTreeItem[]> {
     const selfCodes = await this.selfView.getSelfCodes(this.selected, true);
-    return selfCodes.map((error) => new SelfCodeTreeItem(error));
+
+    if (selfCodes) {
+      return selfCodes.map((error) => new SelfCodeTreeItem(error));
+    }
   }
 }
 


### PR DESCRIPTION
Implement a null check for selfCodes to prevent potential errors when mapping over the results in the getChildren method.