### PR TITLE
Use json-bigint for parsing server response to avoid truncation of large integers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,17 @@
 {
   "name": "vscode-db2i",
-  "version": "1.8.0",
+  "version": "1.8.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vscode-db2i",
-      "version": "1.8.0",
+      "version": "1.8.3",
       "dependencies": {
         "@ibm/mapepire-js": "^0.3.0",
         "chart.js": "^4.4.2",
         "csv": "^6.1.3",
+        "json-bigint": "^1.0.0",
         "json-to-markdown-table": "^1.0.0",
         "lru-cache": "^6.0.0",
         "node-fetch": "^3.3.1",
@@ -1967,6 +1968,7 @@
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/@ibm/mapepire-js/-/mapepire-js-0.3.0.tgz",
       "integrity": "sha512-okub91ElPMU8A2Sm6lsn+AyWV2RLEp0QQnUjIdLeONHu+ZWBmWrIE4gFESbMma8+qhPTco76DNMdrihpwB5gnQ==",
+      "license": "Apache-2.0",
       "dependencies": {
         "ws": "^8.16.0"
       },
@@ -4846,6 +4848,15 @@
       "resolved": "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz",
       "integrity": "sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ==",
       "dev": true,
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/bignumber.js": {
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.1.2.tgz",
+      "integrity": "sha512-2/mKyZH9K85bzOEfhXDBFZTGd1CTs+5IHpeFQo9luiBG7hghdC851Pj2WAhb6E3R6b9tZj/XKhbg4fum+Kepug==",
+      "license": "MIT",
       "engines": {
         "node": "*"
       }
@@ -8597,6 +8608,15 @@
         "canvas": {
           "optional": true
         }
+      }
+    },
+    "node_modules/json-bigint": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
+      "integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bignumber.js": "^9.0.0"
       }
     },
     "node_modules/json-bignum": {

--- a/package.json
+++ b/package.json
@@ -1343,6 +1343,7 @@
     "@ibm/mapepire-js": "^0.3.0",
     "chart.js": "^4.4.2",
     "csv": "^6.1.3",
+    "json-bigint": "^1.0.0",
     "json-to-markdown-table": "^1.0.0",
     "lru-cache": "^6.0.0",
     "node-fetch": "^3.3.1",

--- a/src/connection/sqlJob.ts
+++ b/src/connection/sqlJob.ts
@@ -5,6 +5,7 @@ import { SQLJob } from "@ibm/mapepire-js";
 import { ConnectionResult, JobStatus, QueryResult, ServerRequest, ServerResponse } from "@ibm/mapepire-js/dist/src/types";
 import { JobLogEntry } from "./types";
 import Statement from "../database/statement";
+import JSONbig from "json-bigint";
 
 const DB2I_VERSION = (process.env[`DB2I_VERSION`] || `<version unknown>`) + ((process.env.DEV) ? ``:`-dev`);
 
@@ -73,7 +74,7 @@ export class OldSQLJob extends SQLJob {
               outString = ``;
               if (this.isTracingChannelData) ServerComponent.writeOutput(thisMsg);
               try {
-                let response: ServerResponse = JSON.parse(thisMsg);
+                let response: ServerResponse = JSONbig.parse(thisMsg);
                 this.responseEmitter.emit(response.id, response);
               } catch (e: any) {
                 console.log(`Error: ` + e);


### PR DESCRIPTION
Fixes #324 

JSON.parse will parse integers to Number (IEEE 754 64-bit float) and is limited to values less than what might be returned from the server. This will cause truncation of values less than -9007199254740991 and greater than 9007199254740991 (Number.MAX_SAFE_INTEGER).

This PR changes SQLJob to use json.bigint for parsing the server response. Values will be deserialized to BigInt instead of Number.
