### PR TITLE
Support for null in small columns

### DIFF
--- a/src/views/results/html.ts
+++ b/src/views/results/html.ts
@@ -143,9 +143,13 @@ document.getElementById('resultset').onclick = function(e){
       let bindings = [];
       let updateStatement = 'UPDATE ' + updateTable.table + ' t SET t.' + chosenColumn + ' = ';
 
-      if (newValue === 'null') {
+      if (chosenColumnDetail.maxInputLength >= 4 && newValue === 'null') {
+        // If the column can fit 'null', then set it to null value
         updateStatement += 'NULL';
-
+      } else if (chosenColumnDetail.maxInputLength < 4 && newValue === '-') {
+        // If the column cannot fit 'null', then '-' is the null value
+        updateStatement += 'NULL';
+      
       } else { 
         switch (chosenColumnDetail.jsType) {
           case 'number':


### PR DESCRIPTION
Fixed #332

If there is a column where the max length is less than 4, `null` cannot be entered, so the column cannot be set to null.

This changes the logic so if the column is less than 4 characters long, `-` may be used as null.