### PR TITLE
Ability to run multiple statements

### DIFF
--- a/package.json
+++ b/package.json
@@ -437,6 +437,21 @@
         "icon": "$(window)"
       },
       {
+        "command": "vscode-db2i.runEditorStatement.multiple.all",
+        "title": "Run all statements",
+        "category": "Db2 for i"
+      },
+      {
+        "command": "vscode-db2i.runEditorStatement.multiple.selected",
+        "title": "Run selected statements",
+        "category": "Db2 for i"
+      },
+      {
+        "command": "vscode-db2i.runEditorStatement.multiple.from",
+        "title": "Run statements from cursor",
+        "category": "Db2 for i"
+      },
+      {
         "command": "vscode-db2i.statement.cancel",
         "title": "Cancel",
         "category": "Db2 for i",
@@ -1118,22 +1133,37 @@
         {
           "command": "vscode-db2i.runEditorStatement.inView",
           "when": "editorLangId == sql && vscode-db2i:statementCanCancel != true",
-          "group": "navigation@1"
+          "group": "navigation@2"
+        },
+        {
+          "command": "vscode-db2i.runEditorStatement.multiple.all",
+          "when": "editorLangId == sql && vscode-db2i:statementCanCancel != true && !editorHasSelection",
+          "group": "navigation_multiple@1"
+        },
+        {
+          "command": "vscode-db2i.runEditorStatement.multiple.selected",
+          "when": "editorLangId == sql && vscode-db2i:statementCanCancel != true && editorHasSelection",
+          "group": "navigation_multiple@2"
+        },
+        {
+          "command": "vscode-db2i.runEditorStatement.multiple.from",
+          "when": "editorLangId == sql && vscode-db2i:statementCanCancel != true && !editorHasSelection",
+          "group": "navigation_multiple@2"
         },
         {
           "command": "vscode-db2i.editorExplain.withRun",
           "when": "editorLangId == sql",
-          "group": "2_explain@1"
+          "group": "navigation_explain@1"
         },
         {
           "command": "vscode-db2i.editorExplain.withoutRun",
           "when": "editorLangId == sql",
-          "group": "2_explain@2"
+          "group": "navigation_explain@2"
         },
         {
           "command": "vscode-db2i.notebook.fromSqlUri",
           "when": "editorLangId == sql",
-          "group": "3_notebook@1"
+          "group": "navigation_notebook@1"
         }
       ],
       "notebook/toolbar": [

--- a/src/connection/manager.ts
+++ b/src/connection/manager.ts
@@ -5,7 +5,7 @@ import { OldSQLJob } from "./sqlJob";
 import { askAboutNewJob, onConnectOrServerInstall, osDetail } from "../config";
 import { SelfValue } from "../views/jobManager/selfCodes/nodes";
 import Configuration from "../configuration";
-import { QueryOptions } from "@ibm/mapepire-js/dist/src/types";
+import { QueryOptions, QueryResult } from "@ibm/mapepire-js/dist/src/types";
 import { Query } from "@ibm/mapepire-js/dist/src/query";
 
 export interface JobInfo {
@@ -115,23 +115,25 @@ export class SQLJobManager {
     return this.jobs[jobExists];
   }
 
-  /**
-   * Runs SQL
-   * @param query the SQL query
-   * @param parameters the list of parameters (indicated by '?' parameter parkers in the SQL query)
-   * @param isTerseResults whether the returned data is in terse format. When set to true, the data is returned as an array
-   * of arrays. When set to false, data is returned as an array of objects (compatible with legacy API).
-   * @returns 
-   */
-  async runSQL<T>(query: string, opts?: QueryOptions): Promise<T[]> {
+  async runSQL<T>(query: string, opts?: QueryOptions, rowsToFetch = 2147483647): Promise<T[]> {
     // 2147483647 is NOT arbitrary. On the server side, this is processed as a Java
     // int. This is the largest number available without overflow (Integer.MAX_VALUE)
-    const rowsToFetch = 2147483647;
 
     const statement = await this.getPagingStatement<T>(query, opts);
     const results = await statement.execute(rowsToFetch);
     statement.close();
     return results.data;
+  }
+
+  async runSQLVerbose<T>(query: string, opts?: QueryOptions, rowsToFetch = 2147483647): Promise<QueryResult<T>> {
+    // 2147483647 is NOT arbitrary. On the server side, this is processed as a Java
+    // int. This is the largest number available without overflow (Integer.MAX_VALUE)
+
+    const statement = await this.getPagingStatement<T>(query, opts);
+    const results = await statement.execute(rowsToFetch);
+    statement.close();
+
+    return results;
   }
 
   async getPagingStatement<T>(query: string, opts?: QueryOptions): Promise<Query<T>> {

--- a/src/language/providers/problemProvider.ts
+++ b/src/language/providers/problemProvider.ts
@@ -1,4 +1,4 @@
-import { commands, CompletionItemKind, Diagnostic, DiagnosticSeverity, languages, ProgressLocation, Range, TextDocument, Uri, window, workspace } from "vscode";
+import { commands, CompletionItemKind, Diagnostic, Disposable, DiagnosticSeverity, languages, ProgressLocation, Range, TextDocument, Uri, window, workspace } from "vscode";
 import {
   SQLType,
 } from "../../database/schemas";
@@ -73,7 +73,9 @@ export const checkDocumentDefintion = commands.registerCommand(CHECK_DOCUMENT_CO
   }
 });
 
-export const problemProvider = [
+export const problemProvider: Disposable[] = [
+  sqlDiagnosticCollection, 
+
   workspace.onDidCloseTextDocument(e => {
     // Only clear errors from unsaved files.
     if (e.isUntitled) {

--- a/src/views/results/contributes.json
+++ b/src/views/results/contributes.json
@@ -52,6 +52,21 @@
         "icon": "$(window)"
       },
       {
+        "command": "vscode-db2i.runEditorStatement.multiple.all",
+        "title": "Run all statements",
+        "category": "Db2 for i"
+      },
+      {
+        "command": "vscode-db2i.runEditorStatement.multiple.selected",
+        "title": "Run selected statements",
+        "category": "Db2 for i"
+      },
+      {
+        "command": "vscode-db2i.runEditorStatement.multiple.from",
+        "title": "Run statements from cursor",
+        "category": "Db2 for i"
+      },
+      {
         "command": "vscode-db2i.statement.cancel",
         "title": "Cancel",
         "category": "Db2 for i",
@@ -111,22 +126,37 @@
         {
           "command": "vscode-db2i.runEditorStatement.inView",
           "when": "editorLangId == sql && vscode-db2i:statementCanCancel != true",
-          "group": "navigation@1"
+          "group": "navigation@2"
+        },
+        {
+          "command": "vscode-db2i.runEditorStatement.multiple.all",
+          "when": "editorLangId == sql && vscode-db2i:statementCanCancel != true && !editorHasSelection",
+          "group": "navigation_multiple@1"
+        },
+        {
+          "command": "vscode-db2i.runEditorStatement.multiple.selected",
+          "when": "editorLangId == sql && vscode-db2i:statementCanCancel != true && editorHasSelection",
+          "group": "navigation_multiple@2"
+        },
+        {
+          "command": "vscode-db2i.runEditorStatement.multiple.from",
+          "when": "editorLangId == sql && vscode-db2i:statementCanCancel != true && !editorHasSelection",
+          "group": "navigation_multiple@2"
         },
         {
           "command": "vscode-db2i.editorExplain.withRun",
           "when": "editorLangId == sql",
-          "group": "2_explain@1"
+          "group": "navigation_explain@1"
         },
         {
           "command": "vscode-db2i.editorExplain.withoutRun",
           "when": "editorLangId == sql",
-          "group": "2_explain@2"
+          "group": "navigation_explain@2"
         },
         {
           "command": "vscode-db2i.notebook.fromSqlUri",
           "when": "editorLangId == sql",
-          "group": "3_notebook@1"
+          "group": "navigation_notebook@1"
         }
       ],
       "view/title": [

--- a/src/views/results/index.ts
+++ b/src/views/results/index.ts
@@ -185,7 +185,7 @@ async function runMultipleHandler(mode: `all`|`selected`|`from`) {
       if (group.statements.length >= 1) {
         const statement = group.statements[0];
 
-        if (isStop(statement)) {
+        if (isStop(statement) && i > 0) {
           break;
         }
 


### PR DESCRIPTION
This adds new options under the play button:

Shown when there is no selection:

* Run all statements in the editor
* Run all statements from cursor

Shown when there is a selection:

* Run selected statements

This will execute all statements, but only show the result set for the last statement. Prefixes like `cl`, `csv`, etc, are still allowed and will work as they do when running single statements.

If a statement is execute and it errors, then no more statements will be executed.

If you use `stop`, then the statement execution will stop.