### PR TITLE
Only run certain features when job is ready

### DIFF
--- a/src/language/providers/completionProvider.ts
+++ b/src/language/providers/completionProvider.ts
@@ -611,7 +611,7 @@ export const completionProvider = languages.registerCompletionItemProvider(
           allItems.push(...getLocalDefs(sqlDoc, offset))
         }
 
-        if (remoteAssistIsEnabled() && currentStatement) {
+        if (remoteAssistIsEnabled(false) && currentStatement) {
           allItems.push(...await getCompletionItems(trigger, currentStatement, offset))
         }
 

--- a/src/language/providers/hoverProvider.ts
+++ b/src/language/providers/hoverProvider.ts
@@ -60,7 +60,7 @@ export const openProvider = workspace.onDidOpenTextDocument(async (document) => 
 
 export const hoverProvider = languages.registerHoverProvider({ language: `sql` }, {
   async provideHover(document, position, token) {
-    if (!remoteAssistIsEnabled()) return;
+    if (!remoteAssistIsEnabled(true)) return;
     
     const defaultSchema = getDefaultSchema();
     const sqlDoc = getSqlDocument(document);

--- a/src/language/providers/logic/available.ts
+++ b/src/language/providers/logic/available.ts
@@ -2,11 +2,19 @@
 import { env } from "process";
 import { ServerComponent } from "../../../connection/serverComponent";
 import { JobManager } from "../../../config";
+import { JobInfo } from "../../../connection/manager";
 
 export function localAssistIsEnabled() {
   return (env.DB2I_DISABLE_CA !== `true`);
 }
 
-export function remoteAssistIsEnabled() {
-  return localAssistIsEnabled() && ServerComponent.isInstalled() && JobManager.getSelection() !== undefined;
+export function remoteAssistIsEnabled(needsToBeReady?: boolean): JobInfo|undefined {
+  if (!localAssistIsEnabled()) return;
+  if (!ServerComponent.isInstalled()) return;
+
+  const selection = JobManager.getSelection();
+  if (!selection) return;
+  if (selection.job.getStatus() !== `ready` && needsToBeReady) return;
+
+  return selection;
 }

--- a/src/language/providers/parameterProvider.ts
+++ b/src/language/providers/parameterProvider.ts
@@ -11,9 +11,8 @@ import { getSqlDocument } from "./logic/parse";
 
 export const signatureProvider = languages.registerSignatureHelpProvider({ language: `sql` }, {
   async provideSignatureHelp(document, position, token, context) {
-    const content = document.getText();
     const offset = document.offsetAt(position);
-
+    
     if (remoteAssistIsEnabled()) {
 
       const sqlDoc = getSqlDocument(document);

--- a/src/language/providers/problemProvider.ts
+++ b/src/language/providers/problemProvider.ts
@@ -58,9 +58,7 @@ export function setCheckerAvailableContext(additionalState = true) {
   commands.executeCommand(`setContext`, CHECKER_AVAILABLE_CONTEXT, available);
 }
 
-let checkerRunning = false;
 export function setCheckerRunningContext(isRunning: boolean) {
-  checkerRunning = isRunning;
   commands.executeCommand(`setContext`, CHECKER_RUNNING_CONTEXT, isRunning);
 }
 
@@ -120,7 +118,8 @@ interface SqlDiagnostic extends Diagnostic {
 
 async function validateSqlDocument(document: TextDocument, specificStatement?: number) {
   const checker = SQLStatementChecker.get();
-  if (remoteAssistIsEnabled() && checker && !checkerRunning) {
+  const job = remoteAssistIsEnabled(true);
+  if (checker && job) {
     const basename = document.fileName ? path.basename(document.fileName) : `Untitled`;
     if (isSafeDocument(document)) {
       setCheckerRunningContext(true);
@@ -181,7 +180,7 @@ async function validateSqlDocument(document: TextDocument, specificStatement?: n
 
               let syntaxChecked: SqlSyntaxError[] | undefined;
               try {
-                syntaxChecked = await window.withProgress({ location: ProgressLocation.Window, title: `$(sync-spin) Checking SQL Syntax` }, () => { return checker.checkMultipleStatements(sqlStatementContents) });
+                syntaxChecked = await window.withProgress({ location: ProgressLocation.Window, title: `$(sync-spin) Checking SQL Syntax` }, () => { return checker.checkMultipleStatements(job, sqlStatementContents) });
               } catch (e) {
                 window.showErrorMessage(`${basename}: the SQL syntax checker failed to run. ${e.message}`);
                 syntaxChecked = undefined;


### PR DESCRIPTION
Introduce a mechanism to ensure that a job is only grabbed when it is in a safe state. This change enhances the handling of job selection for the language tools. 

Additionally, adjustments to the remote assist functionality ensure it operates correctly based on job readiness.

This was to solve a bug where the syntax checker would hang while a statement was running.