### PR TITLE
Generate RPG data structure from result metadata

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vscode-db2i",
-  "version": "1.9.4",
+  "version": "1.10.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vscode-db2i",
-      "version": "1.9.4",
+      "version": "1.10.1",
       "dependencies": {
         "@ibm/mapepire-js": "^0.5.0",
         "@octokit/rest": "^21.1.1",


### PR DESCRIPTION
Feature to generate RPG data structure from column metadata.

Added statement qualifier "rpg". E.g:

````
rpg: select cast('' as varchar(100)) as my_text, current_timestamp as my_timestamp, cast(1.0 as numeric(13, 2)) as my_val from sysibm.sysdummy1;
````
generates:
````
**free

-- Row data structure
dcl-ds row_t qualified template;
  my_text varchar(100);
  my_timestamp timestamp;
  my_val zoned(13 : 2);
end-ds;
````
