### PR TITLE
Show column metadata as header row tooltip in result view

### DIFF
--- a/src/views/results/html.ts
+++ b/src/views/results/html.ts
@@ -431,7 +431,36 @@ export function generateScroller(basicSelect: string, isCL: boolean, withCancel?
             var header = document.getElementById(htmlTableId).getElementsByTagName('thead')[0];
             header.innerHTML = '';
             var headerRow = header.insertRow();
-            columnMetaData.map(col => columnHeadings === 'Label' ? col.label : col.name).forEach(colName => headerRow.insertCell().appendChild(document.createTextNode(colName)));
+            columnMetaData.map(column => {
+              var cell = headerRow.insertCell();
+              cell.appendChild(document.createTextNode(columnHeadings === 'Label' ? column.label : column.name));
+              switch (column.type) {
+                case 'CHAR':
+                case 'VARCHAR':
+                case 'CLOB':
+                case 'BINARY':
+                case 'VARBINARY':
+                case 'BLOB':
+                case 'GRAPHIC':
+                case 'VARGRAPHIC':
+                case 'DBCLOB':
+                case 'NCHAR':
+                case 'NVARCHAR':
+                case 'NCLOB':
+                case 'FLOAT':
+                case 'DECFLOAT':
+                case 'TIMESTAMP':
+                case 'DATALINK':
+                  cell.title = column.type + ' (' + column.precision + ')';
+                  break;
+                case 'DECIMAL':
+                case 'NUMERIC':
+                  cell.title = column.type + ' (' + column.precision + ',' + column.scale + ')';
+                  break;
+                default:
+                  cell.title = column.type;
+              }
+            });
 
             // Initialize the footer
             var footer = document.getElementById(htmlTableId).getElementsByTagName('tfoot')[0];


### PR DESCRIPTION
Added column metadata to title property of header-cell in the result view. It will show the column data type, precision and scale.

<img width="342" alt="image" src="https://github.com/user-attachments/assets/c92e24f3-3d36-4c28-964d-9c8e12df1541" />

How to test:
Hover over column headers to view data type