### PR TITLE
Avoid truncation of large integers

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -11,7 +11,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v2
         with:
-          node-version: '20'
+          node-version: '22'
       - uses: actions/checkout@v2
       
       - run: npm ci

--- a/.github/workflows/webpack_ci.yaml
+++ b/.github/workflows/webpack_ci.yaml
@@ -8,7 +8,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [20.x]
+        node-version: [22.x]
 
     steps:
     - uses: actions/checkout@v3

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vscode-db2i",
-  "version": "1.9.4",
+  "version": "1.10.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vscode-db2i",
-      "version": "1.9.4",
+      "version": "1.10.1",
       "dependencies": {
         "@ibm/mapepire-js": "^0.5.0",
         "@octokit/rest": "^21.1.1",
@@ -36,7 +36,7 @@
         "webpack-cli": "^4.5.0"
       },
       "engines": {
-        "vscode": "^1.95.0"
+        "vscode": "^1.101.0"
       }
     },
     "node_modules/@75lb/deep-merge": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Db2 for IBM i tools in VS Code",
   "version": "1.10.1",
   "engines": {
-    "vscode": "^1.95.0"
+    "vscode": "^1.101.0"
   },
   "icon": "media/logo.png",
   "keywords": [

--- a/src/connection/sqlJob.ts
+++ b/src/connection/sqlJob.ts
@@ -73,7 +73,12 @@ export class OldSQLJob extends SQLJob {
               outString = ``;
               if (this.isTracingChannelData) ServerComponent.writeOutput(thisMsg);
               try {
-                let response: ServerResponse = JSON.parse(thisMsg);
+                let response: ServerResponse = JSON.parse(thisMsg, (_key, value, context) => {
+                  if (typeof value === 'number' && ('' + value !== context.source)) {
+                    return context.source;
+                  }
+                  return value;
+                });
                 this.responseEmitter.emit(response.id, response);
               } catch (e: any) {
                 console.log(`Error: ` + e);


### PR DESCRIPTION
Fixes #324

Alternative fix to avoid truncation. Requires node >= 21.

- [x] Wait until VSCode with Electron 35 and node v22 is released
- [ ] Test changes

Update of Electron and Node can be tracked here:
https://redirect.github.com/microsoft/vscode/pull/245423
https://redirect.github.com/microsoft/vscode/issues/250125

Background:

JSON.parse will parse integers to Number (IEEE 754 64-bit float) and is limited to values less than what might be returned from the server. This will cause truncation of values less than -9007199254740991 and greater than 9007199254740991 (Number.MAX_SAFE_INTEGER).