### PR TITLE
Support long and short names in updatable prefix

### DIFF
--- a/src/database/table.ts
+++ b/src/database/table.ts
@@ -70,8 +70,8 @@ export default class Table {
   }
 
   static async isPartitioned(schema: string, name: string): Promise<boolean> {
-    const sql = `select table_name, partitioned_table from qsys2.sysfiles where table_schema = ? and table_name = ? and partitioned_table is not null and partitioned_table = 'YES'`;
-    const parameters = [schema, name];
+    const sql = `select table_name, partitioned_table from qsys2.sysfiles where ((table_schema = ? and table_name = ?) or (system_table_schema = ? and system_table_name = ?)) and partitioned_table is not null and partitioned_table = 'YES'`;
+    const parameters = [schema, name, schema, name];
 
     const result = await JobManager.runSQL(sql, {parameters});
     return result.length > 0;


### PR DESCRIPTION
Enhance the SQL query to support both long and short names for table identification in the partition check.

Fixes #364