### PR TITLE
Implement option to use system names for columns in content assist

### DIFF
--- a/package.json
+++ b/package.json
@@ -211,7 +211,7 @@
       },
       {
         "id": "vscode-db2i.syntax",
-        "title": "SQL Syntax Checking",
+        "title": "SQL Syntax Options",
         "properties": {
           "vscode-db2i.syntax.checkOnOpen": {
             "type": "boolean",
@@ -231,6 +231,11 @@
           "vscode-db2i.syntax.showWarnings": {
             "type": "boolean",
             "description": "Whether SQL syntax warnings should show in the editor",
+            "default": false
+          },
+          "vscode-db2i.syntax.useSystemNames": {
+            "type": "boolean",
+            "description": "Whether to use system names for columns in the content assist",
             "default": false
           }
         }

--- a/src/database/table.ts
+++ b/src/database/table.ts
@@ -15,6 +15,7 @@ export default class Table {
       `SELECT `,
       `  column.TABLE_SCHEMA,`,
       `  column.TABLE_NAME,`,
+      `  column.SYSTEM_COLUMN_NAME,`,
       `  column.COLUMN_NAME,`,
       `  key.CONSTRAINT_NAME,`,
       `  column.DATA_TYPE, `,

--- a/src/language/providers/completionProvider.ts
+++ b/src/language/providers/completionProvider.ts
@@ -10,15 +10,10 @@ import { CTEReference, ClauseType, ObjectRef, StatementType } from "../sql/types
 import { CallableType } from "../../database/callable";
 import { prepareParamType, createCompletionItem, getParmAttributes } from "./logic/completion";
 import { isCallableType, getCallableParameters } from "./logic/callable";
-import { localAssistIsEnabled, remoteAssistIsEnabled } from "./logic/available";
+import { localAssistIsEnabled, remoteAssistIsEnabled, useSystemNames } from "./logic/available";
 import { DbCache } from "./logic/cache";
 import { getSqlDocument } from "./logic/parse";
 import { TableColumn, BasicSQLObject } from "../../types";
-import Configuration from "../../configuration";
-
-function useSystemNames() {
-  return Configuration.get<boolean>(`syntax.useSystemNames`) || false;
-}
 
 export interface CompletionType {
   order: string;

--- a/src/language/providers/contributes.json
+++ b/src/language/providers/contributes.json
@@ -3,7 +3,7 @@
     "configuration": [
       {
         "id": "vscode-db2i.syntax",
-        "title": "SQL Syntax Checking",
+        "title": "SQL Syntax Options",
         "properties": {
           "vscode-db2i.syntax.checkOnOpen": {
             "type": "boolean",
@@ -23,6 +23,11 @@
           "vscode-db2i.syntax.showWarnings": {
             "type": "boolean",
             "description": "Whether SQL syntax warnings should show in the editor",
+            "default": false
+          },
+          "vscode-db2i.syntax.useSystemNames": {
+            "type": "boolean",
+            "description": "Whether to use system names for columns in the content assist",
             "default": false
           }
         }

--- a/src/language/providers/logic/available.ts
+++ b/src/language/providers/logic/available.ts
@@ -3,6 +3,11 @@ import { env } from "process";
 import { ServerComponent } from "../../../connection/serverComponent";
 import { JobManager } from "../../../config";
 import { JobInfo } from "../../../connection/manager";
+import Configuration from "../../../configuration";
+
+export function useSystemNames() {
+  return Configuration.get<boolean>(`syntax.useSystemNames`) || false;
+}
 
 export function localAssistIsEnabled() {
   return (env.DB2I_DISABLE_CA !== `true`);

--- a/src/language/providers/statusProvider.ts
+++ b/src/language/providers/statusProvider.ts
@@ -1,6 +1,7 @@
 import { Disposable, languages, LanguageStatusSeverity } from "vscode";
 import { SQLStatementChecker } from "../../connection/syntaxChecker";
 import { getCheckerTimeout } from "./problemProvider";
+import { useSystemNames } from "./logic/available";
 
 export class Db2StatusProvider extends Disposable {
   private item = languages.createLanguageStatusItem(`sql`, {language: `sql`});
@@ -16,7 +17,12 @@ export class Db2StatusProvider extends Disposable {
       const checker = SQLStatementChecker.get();
       const checkerTimeout = getCheckerTimeout() / 1000;
       this.item.text = `SQL assistance available. ${checker ? `Syntax checking enabled (every ${checkerTimeout}s after editing)` : `Syntax checking not available.`}`;
-      this.item.detail = `You're connected to an IBM i - you can use the advanced SQL language tooling. ${checker ? `` : `Syntax checking not available. This means that the syntax checker did not install when connecting to this system.`}`;
+      this.item.detail = `You're connected to an IBM i. ${checker ? `You can use the advanced SQL language tooling.` : `Syntax checking not available. This means that the syntax checker did not install when connecting to this system.`}`;
+      this.item.detail = [
+        `You're connected to an IBM i.`,
+        checker ? `You can use the advanced SQL language tooling.` : `Syntax checking not available. This means that the syntax checker did not install when connecting to this system.`,
+        (useSystemNames() ? `System names` : `SQL names`) + ` for columns will be used in the content assist.`
+      ].join(` `);
       this.item.severity = checker ? LanguageStatusSeverity.Information : LanguageStatusSeverity.Warning;
     } else {
       this.item.text = `Basic SQL assistance available`;


### PR DESCRIPTION
Introduce a configuration option to enable the use of system names for columns in SQL syntax assistance, enhancing the content assist functionality.

Closed #346 

![image](https://github.com/user-attachments/assets/60f5c0e8-c399-4e85-a116-61755aa9d283)

![image](https://github.com/user-attachments/assets/de1d68b3-be16-46d5-9798-03c18bbf328a)

![image](https://github.com/user-attachments/assets/d98d681f-a003-4243-818b-e9f425dde607)
