### PR TITLE
Fix day one cleanup

### DIFF
--- a/src/views/results/html.ts
+++ b/src/views/results/html.ts
@@ -449,13 +449,12 @@ export function generateScroller(basicSelect: string, isCL: boolean, withCancel?
                 case 'NCLOB':
                 case 'FLOAT':
                 case 'DECFLOAT':
-                case 'TIMESTAMP':
                 case 'DATALINK':
-                  cell.title = column.type + ' (' + column.precision + ')';
+                  cell.title = column.type + '(' + column.precision + ')';
                   break;
                 case 'DECIMAL':
                 case 'NUMERIC':
-                  cell.title = column.type + ' (' + column.precision + ',' + column.scale + ')';
+                  cell.title = column.type + '(' + column.precision + ', ' + column.scale + ')';
                   break;
                 default:
                   cell.title = column.type;

--- a/src/views/schemaBrowser/index.ts
+++ b/src/views/schemaBrowser/index.ts
@@ -167,7 +167,7 @@ export default class schemaBrowser {
 
       vscode.commands.registerCommand(`vscode-db2i.viewPermissions`, async (object: SQLObject) => {
         if (object) {
-          const content = `SELECT AUTHORIZATION_NAME, OBJECT_AUTHORITY,
+          const content = `SELECT AUTHORIZATION_NAME as USER_NAME, OBJECT_AUTHORITY,
           OWNER, OBJECT_OPERATIONAL, OBJECT_MANAGEMENT, OBJECT_EXISTENCE, OBJECT_ALTER, OBJECT_REFERENCE,
           DATA_READ, DATA_ADD, DATA_UPDATE, DATA_DELETE, DATA_EXECUTE FROM QSYS2.OBJECT_PRIVILEGES 
           WHERE OBJECT_SCHEMA='${object.schema}' AND OBJECT_NAME='${object.name}' AND 

--- a/src/views/schemaBrowser/index.ts
+++ b/src/views/schemaBrowser/index.ts
@@ -467,7 +467,8 @@ export default class schemaBrowser {
 
       const data = await Schemas.getObjects(schema, [type], {
         limit: pageSize,
-        offset
+        offset,
+        sort: true
       });
 
       if (data.length > 0) {


### PR DESCRIPTION
This update ensures that 

* database items in the schema browser are sorted alphabetically, improving usability and navigation (Fixes #376)
* the SQL query has been modified to alias AUTHORIZATION_NAME as USER_NAME in the permissions view.
* made a simple change to the formatting of the type in the hover in the results view