### PR TITLE
Use date format = iso

### DIFF
--- a/src/connection/manager.ts
+++ b/src/connection/manager.ts
@@ -35,7 +35,8 @@ export class SQLJobManager {
         "full open": false,
         "transaction isolation": "none",
         "query optimize goal": "1",
-        "block size": "512"
+        "block size": "512",
+        "date format": "iso"
       }));
 
       try {


### PR DESCRIPTION
Fixes #251 

Modified manager.ts#newJob to use date format = iso (jdbc props). I believe this is the default for ACS RSS.

More info:
https://www.ibm.com/support/pages/how-does-toolbox-jdbc-driver-deal-dates-1940-or-after-2039