### PR TITLE
Hide schema browser actions from command palette

### DIFF
--- a/package.json
+++ b/package.json
@@ -750,6 +750,58 @@
           "when": "never"
         },
         {
+          "command": "vscode-db2i.generateSQL",
+          "when": "never"
+        },
+        {
+          "command": "vscode-db2i.getRelatedObjects",
+          "when": "never"
+        },
+        {
+          "command": "vscode-db2i.getMTIs",
+          "when": "never"
+        },
+        {
+          "command": "vscode-db2i.getIndexes",
+          "when": "never"
+        },
+        {
+          "command": "vscode-db2i.getAuthorities",
+          "when": "never"
+        },
+        {
+          "command": "vscode-db2i.getObjectLocks",
+          "when": "never"
+        },
+        {
+          "command": "vscode-db2i.getRecordLocks",
+          "when": "never"
+        },
+        {
+          "command": "vscode-db2i.clearData",
+          "when": "never"
+        },
+        {
+          "command": "vscode-db2i.copyData",
+          "when": "never"
+        },
+        {
+          "command": "vscode-db2i.deleteObject",
+          "when": "never"
+        },
+        {
+          "command": "vscode-db2i.renameObject",
+          "when": "never"
+        },
+        {
+          "command": "vscode-db2i.advisedIndexes",
+          "when": "never"
+        },
+        {
+          "command": "vscode-db2i.clearAdvisedIndexes",
+          "when": "never"
+        },
+        {
           "command": "vscode-db2i.resultset.settings",
           "when": "never"
         },

--- a/src/views/schemaBrowser/contributes.json
+++ b/src/views/schemaBrowser/contributes.json
@@ -122,6 +122,58 @@
         {
           "command": "vscode-db2i.setSchemaFilter",
           "when": "never"
+        },
+        {
+          "command": "vscode-db2i.generateSQL",
+          "when": "never"
+        },
+        {
+          "command": "vscode-db2i.getRelatedObjects",
+          "when": "never"
+        },
+        {
+          "command": "vscode-db2i.getMTIs",
+          "when": "never"
+        },
+        {
+          "command": "vscode-db2i.getIndexes",
+          "when": "never"
+        },
+        {
+          "command": "vscode-db2i.getAuthorities",
+          "when": "never"
+        },
+        {
+          "command": "vscode-db2i.getObjectLocks",
+          "when": "never"
+        },
+        {
+          "command": "vscode-db2i.getRecordLocks",
+          "when": "never"
+        },
+        {
+          "command": "vscode-db2i.clearData",
+          "when": "never"
+        },
+        {
+          "command": "vscode-db2i.copyData",
+          "when": "never"
+        },
+        {
+          "command": "vscode-db2i.deleteObject",
+          "when": "never"
+        },
+        {
+          "command": "vscode-db2i.renameObject",
+          "when": "never"
+        },
+        {
+          "command": "vscode-db2i.advisedIndexes",
+          "when": "never"
+        },
+        {
+          "command": "vscode-db2i.clearAdvisedIndexes",
+          "when": "never"
         }
       ],
       "view/title": [


### PR DESCRIPTION
Hide schema browser actions that doesn't make sense to show in the command palette