### PR TITLE
Result view - include label/name in tooltip

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vscode-db2i",
-  "version": "1.9.4",
+  "version": "1.11.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vscode-db2i",
-      "version": "1.9.4",
+      "version": "1.11.0",
       "dependencies": {
         "@ibm/mapepire-js": "^0.5.0",
         "@octokit/rest": "^21.1.1",

--- a/src/connection/manager.ts
+++ b/src/connection/manager.ts
@@ -35,7 +35,8 @@ export class SQLJobManager {
         "full open": false,
         "transaction isolation": "none",
         "query optimize goal": "1",
-        "block size": "512"
+        "block size": "512",
+        "extended metadata": true
       }));
 
       try {

--- a/src/views/results/html.ts
+++ b/src/views/results/html.ts
@@ -434,33 +434,7 @@ export function generateScroller(basicSelect: string, isCL: boolean, withCancel?
             columnMetaData.map(column => {
               var cell = headerRow.insertCell();
               cell.appendChild(document.createTextNode(columnHeadings === 'Label' ? column.label : column.name));
-              switch (column.type) {
-                case 'CHAR':
-                case 'VARCHAR':
-                case 'CLOB':
-                case 'BINARY':
-                case 'VARBINARY':
-                case 'BLOB':
-                case 'GRAPHIC':
-                case 'VARGRAPHIC':
-                case 'DBCLOB':
-                case 'NCHAR':
-                case 'NVARCHAR':
-                case 'NCLOB':
-                case 'FLOAT':
-                case 'DECFLOAT':
-                case 'DATALINK':
-                  cell.title = column.type + '(' + column.precision + ')';
-                  break;
-                case 'DECIMAL':
-                case 'NUMERIC':
-                  cell.title = column.type + '(' + column.precision + ', ' + column.scale + ')';
-                  break;
-                default:
-                  cell.title = column.type;
-              }
-              cell.title += '\n' + columnHeadings === 'Label' ? column.name : column.label;
-              return cell;
+              cell.title = getTooltip(column, columnHeadings);
             });
 
             // Initialize the footer
@@ -539,9 +513,43 @@ export function generateScroller(basicSelect: string, isCL: boolean, withCancel?
               var headerCells = document.getElementById(htmlTableId).getElementsByTagName('thead')[0].rows[0].cells;
               for (let x = 0; x < headerCells.length; ++x) {
                 headerCells[x].innerText = columnHeadings === 'Label' ? columnMetaData[x].label : columnMetaData[x].name;
+                headerCells[x].title = getTooltip(columnMetaData[x], columnHeadings);
               }
             }
           }
+
+          function getTooltip(column, columnHeadings) {
+            let title = '';
+            switch (column.type) {
+              case 'CHAR':
+              case 'VARCHAR':
+              case 'CLOB':
+              case 'BINARY':
+              case 'VARBINARY':
+              case 'BLOB':
+              case 'GRAPHIC':
+              case 'VARGRAPHIC':
+              case 'DBCLOB':
+              case 'NCHAR':
+              case 'NVARCHAR':
+              case 'NCLOB':
+              case 'FLOAT':
+              case 'DECFLOAT':
+              case 'DATALINK':
+                title = column.type + '(' + column.precision + ')';
+                break;
+              case 'DECIMAL':
+              case 'NUMERIC':
+                title = column.type + '(' + column.precision + ', ' + column.scale + ')';
+                break;
+              default:
+                title = column.type;
+            }
+            title += \`\\n\`;
+            title += columnHeadings === 'Label' ? column.name : column.label;
+            return title;
+          }
+
         </script>
       </head>
       <body style="padding: 0;">

--- a/src/views/results/html.ts
+++ b/src/views/results/html.ts
@@ -459,6 +459,8 @@ export function generateScroller(basicSelect: string, isCL: boolean, withCancel?
                 default:
                   cell.title = column.type;
               }
+              cell.title += '\n' + columnHeadings === 'Label' ? column.name : column.label;
+              return cell;
             });
 
             // Initialize the footer


### PR DESCRIPTION
Fixes #380 

Adds a second line in the tooltip when hovering the result view header that includes label or name depending on what is used in the header.

warning: manager.ts is modified to enable extended metadata by default (this is the same behaviour as ACS).