### PR TITLE
Don't collapse whitespaces in results and output null in italic

### DIFF
--- a/src/views/results/html.ts
+++ b/src/views/results/html.ts
@@ -521,7 +521,12 @@ export function generateScroller(basicSelect: string, isCL: boolean, withCancel?
 
                 if (!isJson) {
                   // Append a text node to the cell
+                  newDiv.style.whiteSpace = "pre";
+                  newDiv.style["font-family"] = "monospace";
                   newDiv.appendChild(document.createTextNode(cell === undefined ? 'null' : cell));
+                  if(cell === undefined || cell === null) {
+                    newDiv.style["font-style"] = "italic";
+                  }
                 }
                 
                 newCell.column = columnName;


### PR DESCRIPTION
Solves #302.

mapepire-server before 2.1.8 will trim leading whitespaces.