### PR TITLE
New configuration option to select csv column delimiter

### DIFF
--- a/package.json
+++ b/package.json
@@ -152,6 +152,16 @@
               "Use the column name",
               "Use the column label\n'Extended metadata' must be set to true in the JDBC configuration"
             ]
+          },
+          "vscode-db2i.codegen.csvColumnDelimiter": {
+            "type": "string",
+            "description": "Delimiter",
+            "default": "Comma",
+            "enum": [
+              "Comma",
+              "Semicolon",
+              "Tab"
+            ]
           }
         }
       },

--- a/src/views/results/contributes.json
+++ b/src/views/results/contributes.json
@@ -43,6 +43,16 @@
               "Use the column name",
               "Use the column label\n'Extended metadata' must be set to true in the JDBC configuration"
             ]
+          },
+          "vscode-db2i.codegen.csvColumnDelimiter": {
+            "type": "string",
+            "description": "Delimiter",
+            "default": "Comma",
+            "enum": [
+              "Comma",
+              "Semicolon",
+              "Tab"
+            ]
           }
         }
       }

--- a/src/views/results/index.ts
+++ b/src/views/results/index.ts
@@ -414,10 +414,28 @@ async function runHandler(options?: StatementInfo) {
               case `sql`:
                 let content = ``;
                 switch (statementDetail.qualifier) {
-                  case `csv`: content = csv.stringify(data, {
-                    header: true,
-                    quoted_string: true,
-                  }); break;
+                  case `csv`: 
+                    let delimiter;
+                    switch (Configuration.get(`codegen.csvColumnDelimiter`)) {
+                      case `Comma`:
+                        delimiter = `,`;
+                        break;
+                      case `Semicolon`:
+                        delimiter = `;`;
+                        break;
+                      case `Tab`:
+                        delimiter = `\t`;
+                        break;
+                      default:
+                        delimiter = `,`;
+                        break;
+                    }
+                    content = csv.stringify(data, {
+                      header: true,
+                      quoted_string: true,
+                      delimiter: delimiter
+                    }); 
+                  break;
                   case `json`: content = JSON.stringify(data, null, 2); break;
 
                   case `sql`:


### PR DESCRIPTION
Greetings from Common Europe Congress! During a session someone asked for semicolon as a CSV column separator when using the csv-qualifier. This PR adds a new configuration option to select between `Comma`(default), `Semicolon`or `Tab`.