### PR TITLE
Disable peek provider in language initialization

### DIFF
--- a/src/language/providers/index.ts
+++ b/src/language/providers/index.ts
@@ -17,7 +17,7 @@ export function languageInit() {
     signatureProvider,
     hoverProvider,
     openProvider,
-    peekProvider,
+    // peekProvider,
     ...problemProvider,
     checkDocumentDefintion,
     sqlLanguageStatus


### PR DESCRIPTION
Remove the peek provider from the language initialization process to streamline functionality.

This is due to a bug in how we're opening the content of the generate statement.

Closes #396