### PR TITLE
Add keyboard shortcut for new SQL document

### DIFF
--- a/src/views/jobManager/contributes.json
+++ b/src/views/jobManager/contributes.json
@@ -265,6 +265,13 @@
           "group": "inline"
         }
       ]
-    }
+    },
+    "keybindings": [
+      {
+        "command": "vscode-db2i.openSqlDocument",
+        "key": "ctrl+alt-n",
+        "mac": "cmd+alt-n"
+      }
+    ]
   }
 }


### PR DESCRIPTION
This PR will add keyboard shortcut Ctrl-Alt-N to the `openSqlDocument` command, for easier creation of new, empty SQL scripts/files.