### PR TITLE
Support for SQL parameters and binding

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vscode-db2i",
-  "version": "1.12.0",
+  "version": "1.13.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vscode-db2i",
-      "version": "1.12.0",
+      "version": "1.13.3",
       "dependencies": {
         "@ibm/mapepire-js": "^0.5.0",
         "@octokit/rest": "^21.1.1",

--- a/src/Storage.ts
+++ b/src/Storage.ts
@@ -1,11 +1,12 @@
 import vscode from 'vscode';
 
 const QUERIES_KEY = `queries`;
-const SERVERCOMPONENT_KEY = `serverVersion`
+const SERVERCOMPONENT_KEY = `serverVersion`;
 
 export interface QueryHistoryItem {
   query: string;
   unix: number;
+  substatements?: string[];
   starred?: boolean;
 }
 

--- a/src/language/providers/actionProvider.ts
+++ b/src/language/providers/actionProvider.ts
@@ -1,0 +1,60 @@
+import { CodeAction, CodeActionKind, languages, TextDocument, Uri, WorkspaceEdit } from "vscode";
+import { remoteAssistIsEnabled } from "./logic/available";
+import { getSqlDocument } from "./logic/parse";
+
+class SqlCodeAction extends CodeAction {
+  constructor(title: string, kind: CodeActionKind, public file: {document: TextDocument, statementOffset: number, bindCount: number}) {
+    super(title, kind);
+  }
+}
+
+const invalidBindingLabels = [`bind`, `cl`];
+
+export const actionProvider = languages.registerCodeActionsProvider({ language: `sql` }, {
+  provideCodeActions(document, range, context, token) {
+    if (range.isEmpty) {
+      const offset = document.offsetAt(range.start);
+
+      const enabled = remoteAssistIsEnabled();
+      if (!enabled) return;
+
+      const sqlDoc = getSqlDocument(document);
+      if (!sqlDoc) return;
+
+      const currentStatement = sqlDoc.getStatementByOffset(offset);
+      const label = currentStatement.getLabel()?.toLowerCase() || ``;
+
+      if (currentStatement && !invalidBindingLabels.includes(label)) {
+        const markers = currentStatement.getEmbeddedStatementAreas().filter(a => a.type === `marker`);
+        const codeActions: SqlCodeAction[] = [];
+
+        if (markers.length > 0) {
+          const action = new SqlCodeAction(`Generate bind statement`, CodeActionKind.QuickFix, {
+            document,
+            statementOffset: currentStatement.range.end,
+            bindCount: markers.length
+          });
+
+          codeActions.push(action);
+
+          return codeActions;
+        }
+      }
+
+      return [];
+    }
+  },
+  resolveCodeAction(codeAction: SqlCodeAction, token) {
+    if (!(codeAction instanceof SqlCodeAction)) return codeAction;
+    codeAction.edit = new WorkspaceEdit();
+    const document = codeAction.file.document;
+
+    const endOfStatementPos = document.positionAt(codeAction.file.statementOffset);
+    const lineOfStatement = document.lineAt(endOfStatementPos.line);
+
+    let statement = `bind: ${new Array(codeAction.file.bindCount).fill(`v`).join(`, `)}`;
+
+    codeAction.edit.insert(document.uri, lineOfStatement.range.end, `\n${statement};`);
+    return codeAction;
+  }
+});

--- a/src/language/providers/actionProvider.ts
+++ b/src/language/providers/actionProvider.ts
@@ -3,7 +3,7 @@ import { remoteAssistIsEnabled } from "./logic/available";
 import { getSqlDocument } from "./logic/parse";
 
 class SqlCodeAction extends CodeAction {
-  constructor(title: string, kind: CodeActionKind, public file: {document: TextDocument, statementOffset: number, bindCount: number}) {
+  constructor(title: string, kind: CodeActionKind, public file: {document: TextDocument, statementOffset: number, names: string[]}) {
     super(title, kind);
   }
 }
@@ -32,7 +32,7 @@ export const actionProvider = languages.registerCodeActionsProvider({ language: 
           const action = new SqlCodeAction(`Generate bind statement`, CodeActionKind.QuickFix, {
             document,
             statementOffset: currentStatement.range.end,
-            bindCount: markers.length
+            names: markers.map(marker => marker.named || `?`)
           });
 
           codeActions.push(action);
@@ -52,7 +52,7 @@ export const actionProvider = languages.registerCodeActionsProvider({ language: 
     const endOfStatementPos = document.positionAt(codeAction.file.statementOffset);
     const lineOfStatement = document.lineAt(endOfStatementPos.line);
 
-    let statement = `bind: ${new Array(codeAction.file.bindCount).fill(`v`).join(`, `)}`;
+    let statement = `bind: ${codeAction.file.names.join(`, `)}`;
 
     codeAction.edit.insert(document.uri, lineOfStatement.range.end, `\n${statement};`);
     return codeAction;

--- a/src/language/providers/index.ts
+++ b/src/language/providers/index.ts
@@ -1,3 +1,4 @@
+import { actionProvider } from "./actionProvider";
 import { completionProvider } from "./completionProvider";
 import { formatProvider } from "./formatProvider";
 import { hoverProvider, openProvider } from "./hoverProvider";
@@ -20,7 +21,8 @@ export function languageInit() {
     // peekProvider,
     ...problemProvider,
     checkDocumentDefintion,
-    sqlLanguageStatus
+    sqlLanguageStatus,
+    actionProvider
   );
   
   return functionality;

--- a/src/language/providers/logic/parse.ts
+++ b/src/language/providers/logic/parse.ts
@@ -18,7 +18,7 @@ export function getSqlDocument(document: TextDocument): Document|undefined {
     }
   }
   
-  const newAsp = new Document(document.getText());
+  const newAsp = new Document(document.getText(), false);
   cached.set(uri, { ast: newAsp, version: document.version });
 
   return newAsp;

--- a/src/language/providers/problemProvider.ts
+++ b/src/language/providers/problemProvider.ts
@@ -287,7 +287,7 @@ function getStatementRangeFromGroup(currentGroup: StatementGroup, groupId: numbe
 
     const label = firstStatement.getLabel();
     if (label) {
-      if (label.toUpperCase() === `CL`) {
+      if ([`CL`, `BIND`].includes(label.toUpperCase())) {
         statementRange.validate = false;
       } else {
         statementRange.start = firstStatement.tokens[2].range.start;

--- a/src/language/sql/document.ts
+++ b/src/language/sql/document.ts
@@ -223,7 +223,7 @@ export default class Document {
     })
   }
 
-  removeEmbeddedAreas(statement: Statement, snippetString?: boolean): ParsedEmbeddedStatement {
+  removeEmbeddedAreas(statement: Statement, replacement: `snippet`|`?`): ParsedEmbeddedStatement {
     const areas = statement.getEmbeddedStatementAreas();
 
     const totalParameters = areas.filter(a => a.type === `marker`).length;
@@ -242,7 +242,14 @@ export default class Document {
         case `marker`:
           const markerContent = newContent.substring(start, end);
 
-          newContent = newContent.substring(0, start) + (snippetString ? `\${${totalParameters-parameterCount}:${markerContent}}` : `?`) + newContent.substring(end) + (snippetString ? `$0` : ``);
+          switch (replacement) {
+            case `snippet`:
+              newContent = newContent.substring(0, start) + `\${${totalParameters-parameterCount}:${markerContent}}` + newContent.substring(end) + `$0`;
+              break;
+            case `?`:
+              newContent = newContent.substring(0, start) + `?` + newContent.substring(end);
+              break;
+          }
       
           parameterCount++;
           break;

--- a/src/language/sql/document.ts
+++ b/src/language/sql/document.ts
@@ -223,7 +223,7 @@ export default class Document {
     })
   }
 
-  removeEmbeddedAreas(statement: Statement, replacement: `snippet`|`?`): ParsedEmbeddedStatement {
+  removeEmbeddedAreas(statement: Statement, replacement: `snippet`|`?` = `?`): ParsedEmbeddedStatement {
     const areas = statement.getEmbeddedStatementAreas();
 
     const totalParameters = areas.filter(a => a.type === `marker`).length;

--- a/src/language/sql/document.ts
+++ b/src/language/sql/document.ts
@@ -223,7 +223,7 @@ export default class Document {
     })
   }
 
-  removeEmbeddedAreas(statement: Statement, replacement: `snippet`|`?` = `?`): ParsedEmbeddedStatement {
+  removeEmbeddedAreas(statement: Statement, options: {replacement: `snippet`|`?`|`values`, values?: any[]} = {replacement: `?`}): ParsedEmbeddedStatement {
     const areas = statement.getEmbeddedStatementAreas();
 
     const totalParameters = areas.filter(a => a.type === `marker`).length;
@@ -242,12 +242,26 @@ export default class Document {
         case `marker`:
           const markerContent = newContent.substring(start, end);
 
-          switch (replacement) {
+          switch (options.replacement) {
             case `snippet`:
               newContent = newContent.substring(0, start) + `\${${totalParameters-parameterCount}:${markerContent}}` + newContent.substring(end) + `$0`;
               break;
             case `?`:
               newContent = newContent.substring(0, start) + `?` + newContent.substring(end);
+              break;
+            case `values`:
+              let valueIndex = totalParameters - parameterCount - 1;
+              if (options.values && options.values.length > valueIndex) {
+                let value = options.values[valueIndex];
+                
+                if (typeof value === `string`) {
+                  value = `'${value.replace(/'/g, `''`)}'`; // Escape single quotes in strings
+                }
+
+                newContent = newContent.substring(0, start) + value + newContent.substring(end);
+              } else {
+                newContent = newContent.substring(0, start) + `?` + newContent.substring(end);
+              }
               break;
           }
       

--- a/src/language/sql/document.ts
+++ b/src/language/sql/document.ts
@@ -269,14 +269,17 @@ export default class Document {
           break;
 
         case `remove`:
-          newContent = newContent.substring(0, start) + newContent.substring(end+1);
+          newContent = newContent.substring(0, start) + newContent.substring(end);
+          if (newContent[start-1] === ` ` && newContent[start] === ` `) {
+            newContent = newContent.substring(0, start-1) + newContent.substring(start);
+          }
           break;
       }
     }
 
     return {
       changed: areas.length > 0,
-      content: newContent,
+      content: newContent.trim(),
       parameterCount
     };
   }

--- a/src/language/sql/statement.ts
+++ b/src/language/sql/statement.ts
@@ -30,7 +30,7 @@ export default class Statement {
 			first = this.tokens[2];
 		}
 
-		const wordValue = first.value?.toUpperCase();
+		const wordValue = first?.value?.toUpperCase();
 
 		this.type = StatementTypeWord[wordValue] || StatementType.Unknown;
 		

--- a/src/language/sql/statement.ts
+++ b/src/language/sql/statement.ts
@@ -662,10 +662,15 @@ export default class Statement {
 		let ranges: {type: "remove"|"marker", range: IRange}[] = [];
 		let intoClause: Token|undefined;
 		let declareStmt: Token|undefined;
+		let lastTokenWasMarker = false;
 
 		for (let i = 0; i < this.tokens.length; i++) {
 			const prevToken = this.tokens[i-1];
 			const currentToken = this.tokens[i];
+
+			if (!tokenIs(currentToken, `colon`)) {
+				lastTokenWasMarker = false;
+			}
 
 			switch (currentToken.type) {
 				case `statementType`:
@@ -752,14 +757,15 @@ export default class Statement {
 
 					if (endToken) {
 						ranges.push({
-							type: `marker`,
+							type: lastTokenWasMarker ? `remove` : `marker`,
 							range: {
 								start: currentToken.range.start,
-								end: endToken.range.end
+								end: (endToken.range.end)
 							}
 						});
 
-						i = followingTokenI;
+						lastTokenWasMarker = true;
+						i = (followingTokenI-1);
 					}
 
 					break;

--- a/src/language/sql/statement.ts
+++ b/src/language/sql/statement.ts
@@ -659,7 +659,7 @@ export default class Statement {
 		// Only these statements support the INTO clause in embedded SQL really
 		const validIntoStatements: StatementType[] = [StatementType.Unknown, StatementType.With, StatementType.Select];
 
-		let ranges: {type: "remove"|"marker", range: IRange}[] = [];
+		let ranges: {type: "remove"|"marker", range: IRange, named?: string}[] = [];
 		let intoClause: Token|undefined;
 		let declareStmt: Token|undefined;
 		let lastTokenWasMarker = false;
@@ -761,7 +761,8 @@ export default class Statement {
 							range: {
 								start: currentToken.range.start,
 								end: (endToken.range.end)
-							}
+							},
+							named: endToken.value
 						});
 
 						lastTokenWasMarker = true;

--- a/src/language/sql/statement.ts
+++ b/src/language/sql/statement.ts
@@ -1,7 +1,7 @@
 import SQLTokeniser, { NameTypes } from "./tokens";
 import { CTEReference, CallableReference, ClauseType, ClauseTypeWord, IRange, ObjectRef, QualifiedObject, StatementType, StatementTypeWord, Token } from "./types";
 
-const tokenIs = (token: Token|undefined, type: string, value?: string) => {
+export const tokenIs = (token: Token|undefined, type: string, value?: string) => {
 	return (token && token.type === type && (value ? token.value?.toUpperCase() === value : true));
 }
 

--- a/src/language/sql/tests/statements.test.ts
+++ b/src/language/sql/tests/statements.test.ts
@@ -1886,7 +1886,7 @@ describe(`Parameter statement tests`, () => {
     const result = document.removeEmbeddedAreas(statement);
     expect(result.parameterCount).toBe(1);
     expect(result.content).toBe([
-      `  SELECT EMPNO, FIRSTNME, LASTNAME, JOB`,
+      `SELECT EMPNO, FIRSTNME, LASTNAME, JOB`,
       `  FROM EMPLOYEE`,
       `  WHERE WORKDEPT = ?`
     ].join(`\n`));
@@ -1958,6 +1958,32 @@ describe(`Parameter statement tests`, () => {
     expect(result.parameterCount).toBe(0);
     expect(result.content + `;`).toBe(content);
     expect(result.changed).toBe(false);
+  });
+
+  test('Remove indicator variables', () => {
+    const content = [
+      `UPDATE CORPDATA.EMPLOYEE`,
+      `SET PHONENO = :NEWPHONE:PHONEIND`,
+      `WHERE EMPNO = :EMPID;`,
+      ``,
+      `bind: '3535', '000110';`,
+    ].join(`\n`);
+
+    const expectedContent = [
+      `UPDATE CORPDATA.EMPLOYEE`,
+      `SET PHONENO = ?`,
+      `WHERE EMPNO = ?`,
+    ].join(`\n`);
+
+    const document = new Document(content);
+    const statements = document.statements;
+    expect(statements.length).toBe(2);
+
+    const statement = statements[0];
+    const result = document.removeEmbeddedAreas(statement);
+    console.log(result.content);
+    expect(result.parameterCount).toBe(2);
+    expect(result.content).toBe(expectedContent);
   });
 
   test(`Callable blocks`, () => {

--- a/src/language/sql/tests/statements.test.ts
+++ b/src/language/sql/tests/statements.test.ts
@@ -1386,7 +1386,7 @@ parserScenarios(`PL body tests`, ({newDoc}) => {
 
     const parameterTokens = medianResultSetProc.getBlockAt(46);
     expect(parameterTokens.length).toBeGreaterThan(0);
-    expect(parameterTokens.map(t => t.type).join()).toBe([`parmType`, `word`, `word`, `openbracket`, `word`, `comma`, `word`, `closebracket`].join());
+    expect(parameterTokens.map(t => t.type).join()).toBe([`parmType`, `word`, `word`, `openbracket`, `number`, `comma`, `number`, `closebracket`].join());
 
     const numRecordsDeclare = statements[1];
     expect(numRecordsDeclare.type).toBe(StatementType.Declare);

--- a/src/language/sql/tokens.ts
+++ b/src/language/sql/tokens.ts
@@ -27,6 +27,13 @@ interface TokenState {
 export default class SQLTokeniser {
   static matchers: Matcher[] = [
     {
+      name: `IS_NUMBER`,
+      match: [
+        { type: `word`, match: (value: string) => {return !isNaN(Number(value)) && !isNaN(parseFloat(value)); }},
+      ],
+      becomes: `number`,
+    },
+    {
       name: `PROCEDURE_PARM_TYPE`,
       match: [{ type: `word`, match: (value: string) => {return [`IN`, `OUT`, `INOUT`].includes(value.toUpperCase())}}],
       becomes: `parmType`,

--- a/src/views/queryHistoryView/index.ts
+++ b/src/views/queryHistoryView/index.ts
@@ -4,6 +4,7 @@ import { Config } from "../../config";
 import { QueryHistoryItem } from "../../Storage";
 
 const openSqlDocumentCommand = `vscode-db2i.openSqlDocument`;
+const openHistoryItemCommand = `vscode-db2i.queryHistory.openItem`;
 
 export class queryHistory implements TreeDataProvider<any> {
   private _onDidChangeTreeData: EventEmitter<TreeItem | undefined | null | void> = new EventEmitter<TreeItem | undefined | null | void>();
@@ -19,24 +20,50 @@ export class queryHistory implements TreeDataProvider<any> {
           window.showTextDocument(doc);
         });
       }),
+
+      commands.registerCommand(openHistoryItemCommand, (item?: QueryHistoryItem) => {
+        if (!item) {
+          return;
+        }
+
+        let content = item.query + `;`;
+
+        if (item.substatements && item.substatements.length > 0) {
+          content += `\n\n-- Substatements: ${item.substatements.length}\n`;
+          content += item.substatements.map(sub => sub + `;`).join(`\n`);
+        }
+
+        workspace.openTextDocument({
+          language: `sql`,
+          content
+        }).then(doc => {
+          window.showTextDocument(doc);
+        });
+      }),
+
       commands.registerCommand(`vscode-db2i.queryHistory.find`, async () => {
         commands.executeCommand('queryHistory.focus');
         commands.executeCommand('list.find');
       }),
 
-      commands.registerCommand(`vscode-db2i.queryHistory.prepend`, async (newQuery?: string) => {
+      commands.registerCommand(`vscode-db2i.queryHistory.prepend`, async (newQuery?: string, substatement?: string) => {
         if (newQuery && Config.ready) {
           let currentList = Config.getPastQueries();
           const existingQueryi = currentList.findIndex(queryItem => queryItem.query.trim() === newQuery.trim());
-          const existingQuery = currentList[existingQueryi];
-
-          const newQueryItem: QueryHistoryItem = {
+          const existingQuery = currentList[existingQueryi] || {
             query: newQuery,
             unix: Math.floor(Date.now() / 1000),
           };
 
-          if (existingQuery) {
-            newQueryItem.starred = existingQuery.starred; // Preserve starred status
+          if (substatement) {
+            if (!existingQuery.substatements) {
+              existingQuery.substatements = [];
+            }
+
+            // If the substatement already exists, don't add it again
+            if (!existingQuery.substatements.includes(substatement)) {
+              existingQuery.substatements.push(substatement);
+            }
           }
       
           // If it exists, remove it
@@ -46,7 +73,7 @@ export class queryHistory implements TreeDataProvider<any> {
       
           // If it's at the top, don't add it, it's already at the top
           if (existingQueryi !== 0) {
-            currentList.splice(0, 0, newQueryItem);
+            currentList.splice(0, 0, existingQuery);
           }
       
           await Config.setPastQueries(currentList);
@@ -193,11 +220,17 @@ class PastQueryNode extends TreeItem {
 
     this.contextValue = `query`;
 
-    this.tooltip = new MarkdownString(['```sql', item.query, '```'].join(`\n`));
+    let markdownLines = ['```sql', item.query];
+
+    if (item.substatements && item.substatements.length > 0) {
+      markdownLines.push(``, `-- substatements: ${item.substatements.length}`);
+    }
+
+    this.tooltip = new MarkdownString(markdownLines.join(`\n`));
 
     this.command = {
-      command: openSqlDocumentCommand,
-      arguments: [item.query],
+      command: openHistoryItemCommand,
+      arguments: [item],
       title: `Open into new document`
     };
 

--- a/src/views/results/binding.ts
+++ b/src/views/results/binding.ts
@@ -46,6 +46,8 @@ export function getLiteralsFromStatement(group: StatementGroup): SqlParameter[] 
         } else {
           literals.push(Number(token.value));
         }
+      } else if (tokenIs(token, `word`, `NULL`)) {
+        literals.push(null);
       }
     }
   }

--- a/src/views/results/binding.ts
+++ b/src/views/results/binding.ts
@@ -18,7 +18,7 @@ export function getPriorBindableStatement(editor: TextEditor, offset: number): {
     if (group.statements.length === 1) {
       const statement = group.statements[0];
       if (!statement.getLabel()) {
-        const newStatement = sqlDocument.removeEmbeddedAreas(statement, `?`);
+        const newStatement = sqlDocument.removeEmbeddedAreas(statement);
         return {
           statement: newStatement.content,
           parameters: newStatement.parameterCount

--- a/src/views/results/binding.ts
+++ b/src/views/results/binding.ts
@@ -18,10 +18,10 @@ export function getPriorBindableStatement(editor: TextEditor, offset: number): {
     if (group.statements.length === 1) {
       const statement = group.statements[0];
       if (!statement.getLabel()) {
-        const markers = statement.getEmbeddedStatementAreas().filter(a => a.type === `marker`);
+        const newStatement = sqlDocument.removeEmbeddedAreas(statement, `?`);
         return {
-          statement: sqlDocument.content.substring(group.range.start, group.range.end),
-          parameters: markers.length
+          statement: newStatement.content,
+          parameters: newStatement.parameterCount
         };
       }
     }
@@ -40,7 +40,7 @@ export function getLiteralsFromStatement(group: StatementGroup): SqlParameter[] 
         literals.push(token.value.substring(1, token.value.length - 1)); // Remove quotes
       } else if (token.type === `number`) {
         // Handle decimal numbers
-        if (tokenIs(tokens[i+1], `number`) && tokenIs(tokens[i+2], `number`)) {
+        if (tokenIs(tokens[i+1], `dot`) && tokenIs(tokens[i+2], `number`)) {
           literals.push(Number(`${token.value}.${tokens[i+2].value}`));
           i += 2; // Skip the next two tokens as they are part of the decimal number
         } else {

--- a/src/views/results/binding.ts
+++ b/src/views/results/binding.ts
@@ -4,7 +4,7 @@ import { StatementGroup } from "../../language/sql/types";
 import { SqlParameter } from "./resultSetPanelProvider";
 import { tokenIs } from "../../language/sql/statement";
 
-export function getPriorBindableStatement(editor: TextEditor, offset: number): string|undefined {
+export function getPriorBindableStatement(editor: TextEditor, offset: number): {statement: string, parameters: number}|undefined {
   const sqlDocument = getSqlDocument(editor.document);
 
   const groups = sqlDocument.getStatementGroups();
@@ -18,7 +18,11 @@ export function getPriorBindableStatement(editor: TextEditor, offset: number): s
     if (group.statements.length === 1) {
       const statement = group.statements[0];
       if (!statement.getLabel()) {
-        return sqlDocument.content.substring(group.range.start, group.range.end);
+        const markers = statement.getEmbeddedStatementAreas().filter(a => a.type === `marker`);
+        return {
+          statement: sqlDocument.content.substring(group.range.start, group.range.end),
+          parameters: markers.length
+        };
       }
     }
   }

--- a/src/views/results/binding.ts
+++ b/src/views/results/binding.ts
@@ -30,7 +30,7 @@ export function getLiteralsFromStatement(group: StatementGroup): SqlParameter[] 
   for (const statement of group.statements) {
     for (const token of statement.tokens) {
       if (token.type === `string`) {
-        literals.push(token.value);
+        literals.push(token.value.substring(1, token.value.length - 1)); // Remove quotes
       }
     }
   }

--- a/src/views/results/html.ts
+++ b/src/views/results/html.ts
@@ -377,9 +377,9 @@ export function generateScroller(basicSelect: string, parameters: SqlParameter[]
                     appendRows(data.rows);
                   }
 
-                  if (data.rows === undefined && totalRows === 0) {
+                  if (data.rows === undefined || totalRows === 0) {
                     document.getElementById(messageSpanId).innerText = 'Statement executed with no result set returned. Rows affected: ' + data.update_count;
-                  } else {
+                  } else if (totalRows > 0) {
                     if (data.executionTime) {
                       document.getElementById(statusId).innerText = (noMoreRows ? ('Loaded ' + totalRows + ' rows in ' + data.executionTime.toFixed() + 'ms. End of data.') : ('Loaded ' + totalRows + ' rows in ' + data.executionTime.toFixed() + 'ms. More available.')) + ' ' + (updateTable ? 'Updatable.' : '');
                     }

--- a/src/views/results/html.ts
+++ b/src/views/results/html.ts
@@ -2,6 +2,7 @@ import { Webview } from "vscode";
 import { getHeader } from "../html";
 
 import Configuration from "../../configuration";
+import { SqlParameter } from "./resultSetPanelProvider";
 
 export function setLoadingText(webview: Webview, text: string) {
   webview.postMessage({
@@ -294,7 +295,7 @@ document.getElementById('resultset').onclick = function(e){
 };
 `;
 
-export function generateScroller(basicSelect: string, isCL: boolean, withCancel?: boolean, updatable?: UpdatableInfo): string {
+export function generateScroller(basicSelect: string, parameters: SqlParameter[] = [], isCL: boolean = false, withCancel: boolean = false, updatable?: UpdatableInfo): string {
   const withCollapsed = Configuration.get<boolean>('collapsedResultSet');
 
   return /*html*/`
@@ -417,6 +418,7 @@ export function generateScroller(basicSelect: string, isCL: boolean, withCancel?
             isFetching = true;
             vscode.postMessage({
               query: basicSelect,
+              parameters: ${JSON.stringify(parameters)},
               isCL: ${isCL},
               queryId: myQueryId
             });

--- a/src/views/results/index.ts
+++ b/src/views/results/index.ts
@@ -163,7 +163,7 @@ export function initialise(context: vscode.ExtensionContext) {
   )
 }
 
-const ALLOWED_PREFIXES_FOR_MULTIPLE: StatementQualifier[] = [`cl`, `json`, `csv`, `sql`, `statement`];
+const ALLOWED_PREFIXES_FOR_MULTIPLE: StatementQualifier[] = [`cl`, `json`, `csv`, `sql`, `statement`, `bind`];
 
 function isStop(statement: Statement) {
   return (statement.type === StatementType.Unknown && statement.tokens.length === 1 && statement.tokens[0].value.toUpperCase() === `STOP`);
@@ -600,7 +600,7 @@ export function parseStatement(editor?: vscode.TextEditor, existingInfo?: Statem
 
   if (sqlDocument) {
     if (statementInfo.qualifier !== `cl`) {
-      statementInfo.embeddedInfo = sqlDocument.removeEmbeddedAreas(statementInfo.statement, `snippet`);
+      statementInfo.embeddedInfo = sqlDocument.removeEmbeddedAreas(statementInfo.statement, {replacement: `snippet`});
     }
   }
 

--- a/src/views/results/index.ts
+++ b/src/views/results/index.ts
@@ -348,7 +348,13 @@ async function runHandler(options?: StatementInfo) {
 
             if (runStatement) {
               parameters = getLiteralsFromStatement(statementDetail.group);
-              statementDetail.content = runStatement;
+
+              if (runStatement.parameters !== parameters.length) {
+                vscode.window.showErrorMessage(`Incorrect number of parameters for statement. Expected ${runStatement.parameters}, got ${parameters.length}.`);
+                return;
+              }
+              
+              statementDetail.content = runStatement.statement;
             }
           }
 

--- a/src/views/results/index.ts
+++ b/src/views/results/index.ts
@@ -353,7 +353,10 @@ async function runHandler(options?: StatementInfo) {
                 vscode.window.showErrorMessage(`Incorrect number of parameters for statement. Expected ${runStatement.parameters}, got ${parameters.length}.`);
                 return;
               }
+
+              vscode.commands.executeCommand(`vscode-db2i.queryHistory.prepend`, runStatement.statement, `bind: ${statementDetail.content}`);
               
+              // Overwrite to run the prior statement
               statementDetail.content = runStatement.statement;
             }
           }

--- a/src/views/results/index.ts
+++ b/src/views/results/index.ts
@@ -602,7 +602,7 @@ export function parseStatement(editor?: vscode.TextEditor, existingInfo?: Statem
   }
 
   if (sqlDocument) {
-    if (statementInfo.qualifier !== `cl`) {
+    if (![`cl`, `bind`].includes(statementInfo.qualifier)) {
       statementInfo.embeddedInfo = sqlDocument.removeEmbeddedAreas(statementInfo.statement, {replacement: `snippet`});
     }
   }

--- a/src/views/results/index.ts
+++ b/src/views/results/index.ts
@@ -600,7 +600,7 @@ export function parseStatement(editor?: vscode.TextEditor, existingInfo?: Statem
 
   if (sqlDocument) {
     if (statementInfo.qualifier !== `cl`) {
-      statementInfo.embeddedInfo = sqlDocument.removeEmbeddedAreas(statementInfo.statement, true);
+      statementInfo.embeddedInfo = sqlDocument.removeEmbeddedAreas(statementInfo.statement, `snippet`);
     }
   }
 

--- a/src/views/results/index.ts
+++ b/src/views/results/index.ts
@@ -577,7 +577,7 @@ export function parseStatement(editor?: vscode.TextEditor, existingInfo?: Statem
   }
 
   if (statementInfo.content) {
-    [`cl`, `json`, `csv`, `sql`, `explain`, `update`, `rpg`].forEach(mode => {
+    [`cl`, `json`, `csv`, `sql`, `explain`, `update`, `rpg`, `bind`].forEach(mode => {
       if (statementInfo.content.trim().toLowerCase().startsWith(mode + `:`)) {
         statementInfo.content = statementInfo.content.substring(mode.length + 1).trim();
 

--- a/src/views/results/index.ts
+++ b/src/views/results/index.ts
@@ -20,7 +20,7 @@ import { ExplainType } from "../../connection/types";
 import { queryResultToRpgDs } from "./codegen";
 import Configuration from "../../configuration";
 
-export type StatementQualifier = "statement" | "update" | "explain" | "onlyexplain" | "json" | "csv" | "cl" | "sql" | "rpg";
+export type StatementQualifier = "statement" | "bind" | "update" | "explain" | "onlyexplain" | "json" | "csv" | "cl" | "sql" | "rpg";
 
 export interface StatementInfo {
   content: string,
@@ -333,10 +333,13 @@ async function runHandler(options?: StatementInfo) {
             if (inWindow) {
               useWindow(`CL results`, options.viewColumn);
             }
-            chosenView.setScrolling(statementDetail.content, true); // Never errors
+            chosenView.setScrolling({
+              basicSelect: statementDetail.content,
+              isCL: true,
+            }); // Never errors
           }
           
-        } else if ([`statement`, `update`].includes(statementDetail.qualifier)) {
+        } else if ([`statement`, `update`, `cl`].includes(statementDetail.qualifier)) {
           // If it's a basic statement, we can let it scroll!
           if (statementDetail.noUi) {
             setCancelButtonVisibility(true);
@@ -353,7 +356,11 @@ async function runHandler(options?: StatementInfo) {
               updatableTable = refs[0];
             }
 
-            chosenView.setScrolling(statementDetail.content, false, undefined, inWindow, updatableTable); // Never errors
+            chosenView.setScrolling({ // Never errors
+              basicSelect: statementDetail.content,
+              withCancel: inWindow,
+              ref: updatableTable,
+            })
           }
 
         } else if ([`explain`, `onlyexplain`].includes(statementDetail.qualifier)) {
@@ -372,7 +379,10 @@ async function runHandler(options?: StatementInfo) {
             if (onlyExplain) {
               chosenView.setLoadingText(`Explained.`, false);
             } else {
-              chosenView.setScrolling(statementDetail.content, false, explained.id); // Never errors
+              chosenView.setScrolling({ // Never errors
+                basicSelect: statementDetail.content,
+                queryId: explained.id,
+              })
             }
 
             explainTree = new ExplainTree(explained.vedata);

--- a/src/views/results/resultSetPanelProvider.ts
+++ b/src/views/results/resultSetPanelProvider.ts
@@ -92,7 +92,7 @@ export class ResultSetPanelProvider implements WebviewViewProvider {
           if (message.query) {
             if (this.currentQuery) {
               // If we get a request for a new query, then we need to close the old one
-              if (this.currentQuery.getId() !== message.queryId) {
+              if (this.currentQuery.getId() === undefined || this.currentQuery.getId() !== message.queryId) {
                 // This is a new query, so we need to clean up the old one
                 await this.currentQuery.close();
                 this.currentQuery = undefined;

--- a/src/views/results/resultSetPanelProvider.ts
+++ b/src/views/results/resultSetPanelProvider.ts
@@ -90,7 +90,6 @@ export class ResultSetPanelProvider implements WebviewViewProvider {
 
         default:
           if (message.query) {
-
             if (this.currentQuery) {
               // If we get a request for a new query, then we need to close the old one
               if (this.currentQuery.getId() !== message.queryId) {
@@ -102,10 +101,7 @@ export class ResultSetPanelProvider implements WebviewViewProvider {
 
             try {
               if (this.currentQuery === undefined) {
-                // We will need to revisit this if we ever allow multiple result tabs like ACS does
-                // Query.cleanup();
-
-                this.currentQuery = await JobManager.getPagingStatement(message.query, { isClCommand: message.isCL, isTerseResults: true });
+                this.currentQuery = await JobManager.getPagingStatement(message.query, { parameters: message.parameters, isClCommand: message.isCL, isTerseResults: true });
               }
 
               if (this.currentQuery.getState() !== "RUN_DONE") {

--- a/src/views/results/resultSetPanelProvider.ts
+++ b/src/views/results/resultSetPanelProvider.ts
@@ -11,6 +11,17 @@ import Table from "../../database/table";
 import Statement from "../../database/statement";
 import { TableColumn } from "../../types";
 
+export type SqlParameter = string|number;
+
+export interface ScrollerOptions {
+  basicSelect: string;
+  parameters?: SqlParameter[];
+  isCL?: boolean;
+  queryId?: string;
+  withCancel?: boolean;
+  ref?: ObjectRef;
+}
+
 export class ResultSetPanelProvider implements WebviewViewProvider {
   _view: WebviewView | WebviewPanel;
   loadingState: boolean;
@@ -193,17 +204,17 @@ export class ResultSetPanelProvider implements WebviewViewProvider {
     }
   }
 
-  async setScrolling(basicSelect: string, isCL = false, queryId: string = ``, withCancel = false, ref?: ObjectRef) {
+  async setScrolling(options: ScrollerOptions) {
     this.loadingState = false;
     await this.focus();
 
     let updatable: html.UpdatableInfo | undefined;
 
-    if (ref) {
-      const schema = ref.object.schema || ref.object.system;
+    if (options.ref) {
+      const schema = options.ref.object.schema || options.ref.object.system;
       if (schema) {
         const goodSchema = Statement.delimName(schema, true);
-        const goodName = Statement.delimName(ref.object.name, true);
+        const goodName = Statement.delimName(options.ref.object.name, true);
 
         try {
           const isPartitioned = await Table.isPartitioned(goodSchema, goodName);
@@ -234,16 +245,16 @@ export class ResultSetPanelProvider implements WebviewViewProvider {
                 }));
 
               if (!currentColumns.some(c => c.useInWhere)) {
-                const cName = ref.alias || `t`;
+                const cName = options.ref.alias || `t`;
 
                 // Support for using a custom column list
-                const selectClauseStart = basicSelect.toLowerCase().indexOf(`select `);
-                const fromClauseStart = basicSelect.toLowerCase().indexOf(`from`);
+                const selectClauseStart = options.basicSelect.toLowerCase().indexOf(`select `);
+                const fromClauseStart = options.basicSelect.toLowerCase().indexOf(`from`);
                 let possibleColumnList: string | undefined;
 
                 possibleColumnList = `${cName}.*`;
                 if (fromClauseStart > 0) {
-                  possibleColumnList = basicSelect.substring(0, fromClauseStart);
+                  possibleColumnList = options.basicSelect.substring(0, fromClauseStart);
                   if (selectClauseStart >= 0) {
                     possibleColumnList = possibleColumnList.substring(selectClauseStart + 7);
 
@@ -254,20 +265,20 @@ export class ResultSetPanelProvider implements WebviewViewProvider {
                 }
 
                 // We need to override the input statement if they want to do updatable
-                const whereClauseStart = basicSelect.toLowerCase().indexOf(`where`);
+                const whereClauseStart = options.basicSelect.toLowerCase().indexOf(`where`);
                 let fromWhereClause: string | undefined;
 
                 if (whereClauseStart > 0) {
-                  fromWhereClause = basicSelect.substring(whereClauseStart);
+                  fromWhereClause = options.basicSelect.substring(whereClauseStart);
                 }
 
 
-                basicSelect = `select rrn(${cName}) as RRN, ${possibleColumnList} from ${schema}.${ref.object.name} as ${cName} ${fromWhereClause || ``}`;
+                options.basicSelect = `select rrn(${cName}) as RRN, ${possibleColumnList} from ${schema}.${options.ref.object.name} as ${cName} ${fromWhereClause || ``}`;
                 currentColumns = [{ name: `RRN`, jsType: `number`, useInWhere: true }, ...currentColumns];
               }
 
               updatable = {
-                table: schema + `.` + ref.object.name,
+                table: schema + `.` + options.ref.object.name,
                 columns: currentColumns
               };
             }
@@ -278,11 +289,11 @@ export class ResultSetPanelProvider implements WebviewViewProvider {
       }
     }
 
-    this._view.webview.html = html.generateScroller(basicSelect, isCL, withCancel, updatable);
+    this._view.webview.html = html.generateScroller(options.basicSelect, options.parameters, options.isCL, options.withCancel, updatable);
 
     this._view.webview.postMessage({
       command: `fetch`,
-      queryId
+      queryId: options.queryId
     });
   }
 


### PR DESCRIPTION
Adds a new prefix, `bind`, which allows users to bind values into prior statements that contain parameter markers or host variables.

```
select * from employee where workdept = ? and salary >= :minSalary;

bind: 'A00', 20000;
bind: 'A00', 40000;
```

You'll also find that when executing `bind` statements, history will be updated to store the original statement and will also include storing the `bind` statement being executed into the history of that statement.

Additionally, fixes some bugs for statement execution.