### PR TITLE
Fix comment for multiline statement in generated RPG

### DIFF
--- a/src/views/results/index.ts
+++ b/src/views/results/index.ts
@@ -427,7 +427,8 @@ async function runHandler(options?: StatementInfo) {
             setCancelButtonVisibility(false);
             updateStatusBar({executing: false});
             let content = `**free\n\n`
-              + `// statement: ${statementDetail.content}\n\n`
+              + `// statement:\n`
+              + `// ${statementDetail.content.replace(/(\r\n|\r|\n)/g, '\n// ') }\n\n`
               + `// Row data structure\n`
               + queryResultToRpgDs(result, Configuration.get(`codegen.rpgSymbolicNameSource`));
             const textDoc = await vscode.workspace.openTextDocument({ language: 'rpgle', content });


### PR DESCRIPTION
When using rpg-qualifier on multiline statement, the statement was inserted as a comment with "//" only on the first line.