### PR TITLE
Add ability to set Java version in VS Code settings

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,6 +62,21 @@
             "description": "Saved configs for",
             "default": {},
             "additionalProperties": true
+          },
+          "vscode-db2i.jobJava": {
+            "type": "string",
+            "description": "Java version for Server Component",
+            "default": "/QOpenSys/QIBM/ProdData/JavaVM/jdk80/64bit/bin/java",
+            "enum": [
+              "/QOpenSys/QIBM/ProdData/JavaVM/jdk80/64bit/bin/java",
+              "/QOpenSys/QIBM/ProdData/JavaVM/jdk17/64bit/bin/java",
+              "/QOpenSys/QIBM/ProdData/JavaVM/jdk21/64bit/bin/java"
+            ],
+            "enumDescriptions": [
+              "Java 8 (system default)",
+              "Java 17",
+              "Java 21"
+            ]
           }
         }
       },

--- a/src/connection/serverComponent.ts
+++ b/src/connection/serverComponent.ts
@@ -10,8 +10,10 @@ import { SERVER_VERSION_FILE } from "./SCVersion";
 import IBMi from "@halcyontech/vscode-ibmi-types/api/IBMi";
 import * as Crypto from 'crypto';
 import { readFileSync } from "fs";
+import Configuration from "../configuration";
 
 const ExecutablePathDir = `$HOME/.vscode/`;
+const DEFAULT_JAVA_EIGHT = `/QOpenSys/QIBM/ProdData/JavaVM/jdk80/64bit/bin/java`;
 
 export enum UpdateStatus {
   FAILED,
@@ -50,8 +52,10 @@ export class ServerComponent {
   static getInitCommand(): string | undefined {
     const path = this.getComponentPath();
 
+    const jvmVersion = Configuration.get<string>(`jobJava`) || DEFAULT_JAVA_EIGHT;
+
     if (path) {
-      return `/QOpenSys/QIBM/ProdData/JavaVM/jdk80/64bit/bin/java -Dos400.stdio.convert=N -jar ${path} --single`
+      return `${jvmVersion} -Dos400.stdio.convert=N -jar ${path} --single`
     }
   }
 

--- a/src/contributes.json
+++ b/src/contributes.json
@@ -21,6 +21,21 @@
             "description": "Saved configs for",
             "default": {},
             "additionalProperties": true
+          },
+          "vscode-db2i.jobJava": {
+            "type": "string",
+            "description": "Java version for Server Component",
+            "default": "/QOpenSys/QIBM/ProdData/JavaVM/jdk80/64bit/bin/java",
+            "enum": [
+              "/QOpenSys/QIBM/ProdData/JavaVM/jdk80/64bit/bin/java",
+              "/QOpenSys/QIBM/ProdData/JavaVM/jdk17/64bit/bin/java",
+              "/QOpenSys/QIBM/ProdData/JavaVM/jdk21/64bit/bin/java"
+            ],
+            "enumDescriptions": [
+              "Java 8 (system default)",
+              "Java 17",
+              "Java 21"
+            ]
           }
         }
       },


### PR DESCRIPTION
Introduce a new setting to specify the Java version for the Server Component, allowing users to choose between Java 8, 17, and 21. Default value is set to Java 8.

Need to update docs.

Closes #426