### PR TITLE
Call actions for procedures and functions

### DIFF
--- a/package.json
+++ b/package.json
@@ -601,6 +601,11 @@
         "category": "Db2 for i"
       },
       {
+        "command": "vscode-db2i.generateRoutineCall",
+        "title": "Generate call statement",
+        "category": "Db2 for i"
+      },
+      {
         "command": "vscode-db2i.getRelatedObjects",
         "title": "Get Related Objects",
         "category": "Db2 for i"
@@ -1090,6 +1095,10 @@
           "when": "never"
         },
         {
+          "command": "vscode-db2i.generateRoutineCall",
+          "when": "never"
+        },
+        {
           "command": "vscode-db2i.getRelatedObjects",
           "when": "never"
         },
@@ -1443,6 +1452,11 @@
           "command": "vscode-db2i.getResultSet",
           "when": "viewItem == table || viewItem == view || viewItem == alias",
           "group": "inline"
+        },
+        {
+          "command": "vscode-db2i.generateRoutineCall",
+          "when": "viewItem == procedure || viewItem == function",
+          "group": "db2@1"
         },
         {
           "submenu": "generateSQLSubmenu",

--- a/src/database/callable.ts
+++ b/src/database/callable.ts
@@ -3,6 +3,7 @@ import { JobManager } from "../config";
 import { SQLParm } from "../types";
 
 export type CallableType = "PROCEDURE"|"FUNCTION";
+export type FunctionType = "SCALAR"|"COLUMN"|"TABLE";
 export interface CallableRoutine {
   schema: string;
   name: string;
@@ -35,6 +36,21 @@ export default class Callable {
     if (result.length > 0) {
       routine.specificNames = result.map(row => row.SPECIFIC_NAME);
       return routine;
+    }
+
+    return;
+  }
+
+  static async getFunctionType(schema: string, specificName: string): Promise<FunctionType|undefined> {
+    const result = await JobManager.runSQL<{FUNCTION_TYPE: string}>(
+      `select FUNCTION_TYPE from qsys2.sysfuncs where SPECIFIC_SCHEMA = ? and SPECIFIC_NAME = ?`,
+      {parameters: [schema, specificName]}
+    );
+
+    switch (result[0]?.FUNCTION_TYPE?.trim()) {
+      case `S`: return `SCALAR`;
+      case `C`: return `COLUMN`;
+      case `T`: return `TABLE`;
     }
 
     return;

--- a/src/views/schemaBrowser/contributes.json
+++ b/src/views/schemaBrowser/contributes.json
@@ -51,6 +51,11 @@
         "category": "Db2 for i"
       },
       {
+        "command": "vscode-db2i.generateRoutineCall",
+        "title": "Generate call statement",
+        "category": "Db2 for i"
+      },
+      {
         "command": "vscode-db2i.getRelatedObjects",
         "title": "Get Related Objects",
         "category": "Db2 for i"
@@ -162,6 +167,10 @@
           "when": "never"
         },
         {
+          "command": "vscode-db2i.generateRoutineCall",
+          "when": "never"
+        },
+        {
           "command": "vscode-db2i.getRelatedObjects",
           "when": "never"
         },
@@ -237,6 +246,11 @@
           "command": "vscode-db2i.getResultSet",
           "when": "viewItem == table || viewItem == view || viewItem == alias",
           "group": "inline"
+        },
+        {
+          "command": "vscode-db2i.generateRoutineCall",
+          "when": "viewItem == procedure || viewItem == function",
+          "group": "db2@1"
         },
         {
           "submenu": "generateSQLSubmenu",

--- a/src/views/schemaBrowser/contributes.json
+++ b/src/views/schemaBrowser/contributes.json
@@ -52,7 +52,7 @@
       },
       {
         "command": "vscode-db2i.generateRoutineCall",
-        "title": "Generate call statement",
+        "title": "Generate Call Statement",
         "category": "Db2 for i"
       },
       {

--- a/src/views/schemaBrowser/index.ts
+++ b/src/views/schemaBrowser/index.ts
@@ -9,11 +9,12 @@ import Configuration from "../../configuration";
 
 import { parse } from "csv/sync";
 import { TextDecoder } from "util";
+import Callable from "../../database/callable";
 import Statement from "../../database/statement";
 import { BasicSQLObject } from "../../types";
 import Types from "../types";
 import { getCopyUi } from "./copyUI";
-import { getAdvisedIndexesStatement, getAuthoritiesStatement, getIndexesStatement, getMTIStatement, getObjectLocksStatement, getRecordLocksStatement, getRelatedObjects } from "./statements";
+import { getAdvisedIndexesStatement, getAuthoritiesStatement, getIndexesStatement, getMTIStatement, getObjectLocksStatement, getRecordLocksStatement, getRelatedObjects, getRoutineCallStatement, RoutineInvocation } from "./statements";
 
 const itemIcons = new Map(Object.entries({
   "table": `split-horizontal`,
@@ -186,6 +187,30 @@ export default class SchemaBrowser {
               vscode.window.showErrorMessage(e.message);
             }
           });
+        }
+      }),
+
+      vscode.commands.registerCommand(`vscode-db2i.generateRoutineCall`, async (object: SQLObject) => {
+        if (object && Schemas.isRoutineType(object.type)) {
+          try {
+            const content = await vscode.window.withProgress({ location: vscode.ProgressLocation.Window, title: `Generating call statement` }, async () => {
+              // The specific name resolves overloaded routines to the signature that was picked
+              const specificName = object.uniqueName();
+              const [signature] = await Callable.getSignaturesFor(object.schema, [specificName]);
+
+              let invocation: RoutineInvocation = `PROCEDURE`;
+              if (object.type === `function`) {
+                invocation = (await Callable.getFunctionType(object.schema, specificName)) === `TABLE` ? `TABLE` : `SCALAR`;
+              }
+
+              return getRoutineCallStatement(object.schema, object.name, signature ? signature.parms : [], invocation);
+            });
+
+            const textDoc = await vscode.workspace.openTextDocument({ language: `sql`, content });
+            await vscode.window.showTextDocument(textDoc);
+          } catch (e: any) {
+            vscode.window.showErrorMessage(e.message);
+          }
         }
       }),
 

--- a/src/views/schemaBrowser/statements.ts
+++ b/src/views/schemaBrowser/statements.ts
@@ -11,7 +11,7 @@ export function getRoutineCallStatement(schema: string, name: string, parms: SQL
 
   switch (invocation) {
     case `PROCEDURE`: return `CALL ${call};`;
-    case `TABLE`: return `SELECT * FROM TABLE(${call}) as a;`;
+    case `TABLE`: return `SELECT * FROM TABLE(${call}) AS A;`;
     default: return `VALUES ${call};`;
   }
 }

--- a/src/views/schemaBrowser/statements.ts
+++ b/src/views/schemaBrowser/statements.ts
@@ -1,4 +1,43 @@
 import Statement from "../../database/statement";
+import { prepareParamType } from "../../language/providers/logic/completion";
+import { SQLParm } from "../../types";
+
+export type RoutineInvocation = "PROCEDURE" | "SCALAR" | "TABLE";
+
+export function getRoutineCallStatement(schema: string, name: string, parms: SQLParm[], invocation: RoutineInvocation) {
+  const qualifiedName = `${Statement.delimName(schema)}.${Statement.delimName(name)}`;
+  // The arguments of a table function sit one level deeper, inside the TABLE() clause
+  const call = `${qualifiedName}(${getArgumentList(parms, invocation === `TABLE` ? `  ` : ``)})`;
+
+  switch (invocation) {
+    case `PROCEDURE`: return `CALL ${call};`;
+    case `TABLE`: return `SELECT * FROM TABLE(${call}) as a;`;
+    default: return `VALUES ${call};`;
+  }
+}
+
+function getArgumentList(parms: SQLParm[], indent: string) {
+  if (parms.length === 0) {
+    return ``;
+  }
+
+  // External routines can be created without naming their parameters, so only use named arguments when they all have one
+  const useNames = parms.every(parm => parm.PARAMETER_NAME);
+
+  const args = parms.map(parm => {
+    const value = parm.PARAMETER_MODE === `OUT` ? `?` : (parm.DEFAULT || `?`);
+    return useNames ? `${Statement.delimName(parm.PARAMETER_NAME)} => ${value}` : value;
+  });
+
+  const width = Math.max(...args.map(arg => arg.length)) + 1;
+
+  const lines = args.map((arg, i) => {
+    const argument = arg + (i < args.length - 1 ? `,` : ``);
+    return `${indent}  ${argument.padEnd(width)} -- ${parms[i].PARAMETER_MODE} ${prepareParamType(parms[i])}`;
+  });
+
+  return [``, ...lines, indent].join(`\n`);
+}
 
 export function getRelatedObjects(schema: string, name: string) {
   return `SELECT SQL_NAME, SYSTEM_NAME, SCHEMA_NAME, LIBRARY_NAME, SQL_OBJECT_TYPE, 


### PR DESCRIPTION
### Changes
This PR enables the generation of CALL or SELECT statements for procedures and functions (table and scalar).

### How to test this PR
From the SCHEMA BROWSER, select a procedure or a function (scalar or table), the “Generate Call Statement” option will appear. Click it. A new tab will open with the SQL code for querying or calling the function/procedure.
<img width="421" height="190" alt="image" src="https://github.com/user-attachments/assets/a7681603-8119-4afc-8aee-d8fcdc1f71e2" />

Procedure:
<img width="518" height="139" alt="image" src="https://github.com/user-attachments/assets/45b66ec9-3158-488c-93a9-b7c1a548a22c" />

Scalar function:
<img width="586" height="142" alt="image" src="https://github.com/user-attachments/assets/dd87c002-d6f7-4f32-ad40-2fddb18e2bb6" />

Table function:
<img width="553" height="124" alt="image" src="https://github.com/user-attachments/assets/941f36e2-2609-4325-9b23-2789a79fd658" />

@forstie @ryan-moeller21 could you test it?

### Checklist
* [x] have tested my change
* [ ] have created one or more test cases
* [ ] updated relevant documentation
* [ ] Remove any/all `console.log`s I added
* [x] have added myself to the contributors' list in [CONTRIBUTING.md](https://github.com/codefori/vscode-ibmi/blob/master/CONTRIBUTING.md)

Closes #221 