### PR TITLE
Fix parsing of host variables in obfuscated procedures and functions

### DIFF
--- a/src/language/sql/statement.ts
+++ b/src/language/sql/statement.ts
@@ -660,6 +660,11 @@ export default class Statement {
 	 * DECLARE .. CURSOR FOR
 	 */
 	getEmbeddedStatementAreas() {
+		// WRAPPED statements have an obfuscated body that may contain colons as part of the encoding so avoid parsing them as host variables
+		if (this.tokens.some(t => tokenIs(t, `word`, `WRAPPED`))) {
+			return [];
+		}
+
 		// Only these statements support the INTO clause in embedded SQL really
 		const validIntoStatements: StatementType[] = [StatementType.Unknown, StatementType.With, StatementType.Select];
 

--- a/src/language/sql/statement.ts
+++ b/src/language/sql/statement.ts
@@ -660,11 +660,6 @@ export default class Statement {
 	 * DECLARE .. CURSOR FOR
 	 */
 	getEmbeddedStatementAreas() {
-		// WRAPPED statements have an obfuscated body that may contain colons as part of the encoding so avoid parsing them as host variables
-		if (this.tokens.some(t => tokenIs(t, `word`, `WRAPPED`))) {
-			return [];
-		}
-
 		// Only these statements support the INTO clause in embedded SQL really
 		const validIntoStatements: StatementType[] = [StatementType.Unknown, StatementType.With, StatementType.Select];
 
@@ -672,10 +667,16 @@ export default class Statement {
 		let intoClause: Token | undefined;
 		let declareStmt: Token | undefined;
 		let lastTokenWasMarker = false;
+		let inWrappedBody = false;
 
 		for (let i = 0; i < this.tokens.length; i++) {
 			const prevToken = this.tokens[i - 1];
 			const currentToken = this.tokens[i];
+
+			// WRAPPED statements have an obfuscated body that may contain colons as part of the encoding so avoid parsing them as host variables
+			if (tokenIs(currentToken, `word`, `WRAPPED`)) {
+				inWrappedBody = true;
+			}
 
 			if (!tokenIs(currentToken, `colon`)) {
 				lastTokenWasMarker = false;
@@ -739,6 +740,7 @@ export default class Statement {
 					break;
 
 				case `colon`:
+					if (inWrappedBody) continue;
 					if (intoClause) continue;
 					if (declareStmt) continue;
 					if (prevToken && prevToken.type === `string`) continue;

--- a/src/language/sql/tests/statements.test.ts
+++ b/src/language/sql/tests/statements.test.ts
@@ -1775,6 +1775,17 @@ describe(`Parameter statement tests`, () => {
     expect(markerRanges.length).toBe(2);
   });
 
+  test('WRAPPED statement body colons should not be treated as host variables', () => {
+    const document = new Document(`CREATE FUNCTION SALARY ( WAGE DECFLOAT )  WRAPPED QSQ07040 aacxW8plW8VzG8pHG8VvG8Fv68pb68FHl8:d39pl2qpdW8pdW8pdW9pjaqebaqebaCyIiKAHDATfmviU2_csLwxF1GUVlfERKBQfPcs79kF1EUT7VTiNQ_TmNQ_Sa`);
+    const statements = document.statements;
+    expect(statements.length).toBe(1);
+
+    const statement = statements[0];
+
+    const markerRanges = statement.getEmbeddedStatementAreas();
+    expect(markerRanges.length).toBe(0);
+  });
+
   test('JSON_OBJECT parameters should not mark as embedded', () => {
     const document = new Document(`values json_object('model_id': 'meta-llama/llama-2-13b-chat', 'input': 'TEXT', 'parameters': json_object('max_new_tokens': 100, 'time_limit': 1000), 'space_id': 'SPACEID')`);
     const statements = document.statements;


### PR DESCRIPTION
### Changes
WRAPPED statements have an obfuscated body that may contain colons as part of the encoding. Previously running this procedure/function like this would incorrectly detect host variables which would also cause a truncation issue.

https://www.ibm.com/docs/en/i/7.6.0?topic=functions-wrap

### How to test this PR
1. Generate an obfuscated function:
```sql
VALUES SYSIBMADM.WRAP('CREATE FUNCTION salary(wage DECFLOAT) RETURNS DECFLOAT 
                                RETURN wage * 40 * 52');
```
2. Run the function it generates:
```sql
CREATE FUNCTION SALARY ( WAGE DECFLOAT )  WRAPPED QSQ07040 aacxW8plW8VzG8pHG8VvG8Fv68Vn68Fbl8pJY8pJ1qpdW8pdW8pdW9pjaqebaqebakZuBeEd5uFkq8KJqqYsjm:1m0gyYOktd1gfJbJ0J8Pq1JRTtWhZ7eZZ7e4aa
```
3. Observe that the statement ran successfully.


### Checklist
* [x] have tested my change
* [x] have created one or more test cases
